### PR TITLE
Adds support for reading type descriptors.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+package-lock.json

--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 # ion-binary-explorer
 
+Disclaimer: The author (jonwilsdon) works for Amazon; however, this project is a side project and is not an Amazon project.
+
 This package is considered *ALPHA* software and has bugs.
 
 The code that is running on the `gh-pages` branch will be added to the `main` branch incrementally.
 
-Disclaimer: The author (jonwilsdon) works for Amazon; however, this project is a side project and is not an Amazon project.
+## Testing
+
+To run the tests, use `npm test`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "ion-binary-explorer",
+  "version": "0.0.1",
+  "description": "Explores Ion Binary files.",
+  "main": "index.js",
+  "dependencies": {},
+  "devDependencies": {
+    "chai": "^4.3.6",
+    "mocha": "^10.0.0"
+  },
+  "scripts": {
+    "test": "mocha"
+  },
+  "mocha": {
+    "check-leaks": true,
+    "diff": true,
+    "extension": ["js"],
+    "recursive": true,
+    "watch-files": ["test/**/*.js"]
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jonwilsdon/ion-binary-explorer.git"
+  },
+  "author": "Jon Wilsdon",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/jonwilsdon/ion-binary-explorer/issues"
+  },
+  "homepage": "https://github.com/jonwilsdon/ion-binary-explorer#readme"
+}

--- a/src/core/ByteBufferReader.js
+++ b/src/core/ByteBufferReader.js
@@ -1,0 +1,161 @@
+'use strict';
+
+const br = require('./ByteReader');
+
+/**
+ * Reads bytes from a buffer.
+ * Extends ByteReader interface.
+ */
+class ByteBufferReader extends br.ByteReader {
+
+  #sourceBuffer = null;
+  #uint8Buffer = null;
+
+  /**
+   * The current position to read from in the buffer
+   */
+  #positionInBuffer = 0;
+  
+  constructor () {
+    super();
+  }
+
+  /**
+   * Loads a buffer into the ByteBufferReader.
+   * 
+   * @param {ArrayBuffer | Uint8Array} buffer
+   * @throws Error if the buffer does not exist.
+   * @returns {Number} the number of bytes in the buffer
+   */
+  loadBuffer (buffer) {
+    this.#sourceBuffer = buffer;
+
+    if (this.#sourceBuffer === null || this.#sourceBuffer === undefined) {
+      // TODO: pass the error to the caller
+      const err = new Error(`called with a ${this.#sourceBuffer} buffer.`);
+      throw err;
+    }
+
+    if (this.#sourceBuffer instanceof ArrayBuffer) {
+      this.#uint8Buffer = new Uint8Array(this.#sourceBuffer);
+    } else if (this.#sourceBuffer instanceof Uint8Array) {
+      this.#uint8Buffer = this.#sourceBuffer;
+    } else {
+      // TODO: pass the error to the caller
+      const err = new Error(`ByteBufferReader loadBuffer() called with an unsupported buffer type.`);
+      throw err;
+    }
+
+    return this.#uint8Buffer.length;
+  }
+
+  /**
+   * Reads the nextByte from the current position in the buffer.
+   * Moves the current position forward by 1 byte.
+   * 
+   * @returns {null | UInt8}
+   * - null if the current position is currently at the end of the buffer
+   * - the UInt8 at that position in the buffer
+   */
+  nextByte () {
+    if (this.atEnd()) {
+      return null;
+    }
+
+    if (typeof this.#positionInBuffer === 'bigint') {
+      if (this.#positionInBuffer+1n > this.#uint8Buffer.length) {
+        return null;
+      }
+    } else {
+      if (this.#positionInBuffer+1 > this.#uint8Buffer.length) {
+        return null;
+      }
+    }
+
+    const byte = this.#uint8Buffer[this.#positionInBuffer];
+    this.#positionInBuffer++;
+
+    return byte;
+  }
+
+  /**
+   * Skips forward the specified number of bytes.
+   * Note: This function does not check if the number of bytes to skip are valid.
+   * 
+   * @param {Number} numBytesToSkip The number of bytes for the reader to skip over.
+   */
+  skipBytes (numBytesToSkip) {
+    this.#positionInBuffer += numBytesToSkip;
+  }
+
+  /**
+   * Sets the position in the buffer to be the byte number passed in.
+   * Note: This function does not check if the position to set is valid.
+   * 
+   * @param {Number} positionToSet The new position to set the reader to.
+   */
+  setPosition (positionToSet) {
+    this.#positionInBuffer = positionToSet;
+  }
+
+  /**
+   * Checks if the specified position is exactly at the end of the buffer.
+   * Throws an error if the position is beyond the end of the buffer.
+   * @param {Number} position The position to check.
+   * @returns {Boolean}
+   * - true if the position is at the end of the buffer
+   * - false if the position is still within the buffer
+   */
+  atEnd (position) {
+    if (typeof position === "bigint") {
+      if (position === BigInt(this.#uint8Buffer.length)) {
+        return true;
+      }
+
+      if (position > BigInt(this.#uint8Buffer.length)) {
+        return null;
+      }
+    } else {
+      if (position === this.#uint8Buffer.length) {
+        return true;
+      }
+      
+      if (position > this.#uint8Buffer.length) {
+        return null;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * Returns a specified amount of raw bytes from the buffer at a specified offset. 
+   * 
+   * @param {Number} offset The offset to start from.
+   * @param {Number} length The number of bytes to pull from the buffer.
+   * @returns {Uint8Array}
+   */
+  rawBytes(offset, length) {
+    return this.#uint8Buffer.slice(offset, offset+length);
+  }
+
+  /**
+   * Returns the current position in the buffer
+   * 
+   * @returns {Number}
+   */
+  get positionInBuffer() {
+    return this.#positionInBuffer;
+  }
+
+  /**
+   * Returns the size (length) of the buffer.
+   * 
+   * @returns {Number}
+   */
+  get size() {
+    return this.#uint8Buffer.length;
+  }
+}
+
+exports.ByteBufferReader = ByteBufferReader;

--- a/src/core/ByteReader.js
+++ b/src/core/ByteReader.js
@@ -1,0 +1,355 @@
+'use strict';
+
+/**
+ * "Abstract" or "Pure virtual" class that provides a consistent interface for reading bytes.
+ * nextByte, skipBytes, setPosition, atEnd, size, readVarUInt, readUInt, readVarInt, readInt
+ */
+class ByteReader {
+  
+  /**
+   * no parameters required
+   */
+  constructor() {}
+
+  /**
+   * Returns the next byte.
+   * 
+   * @returns {null} if the next byte is beyond the current set of bytes available
+   */
+  nextByte() {
+    return null;
+  }
+
+  /**
+   * Moves the reader by the specified number of bytes.
+   * 
+   * @param {Number} numBytesToSkip The number of bytes to skip.
+   * - accepts positive numbers to skip forwards
+   * - accepts negative numbers to skip backwards
+   * @returns {null}
+   * null if numBytesToSkip is beyond the current set of bytes available
+   */
+  skipBytes(numBytesToSkip) {
+    return null;
+  }
+
+  /**
+   * Sets the reader position to the specified offset
+   * 
+   * @param {Number} positionToSet
+   * @returns {null} 
+   * null if positionToSet is beyond the current set of bytes available
+   */
+  setPosition(positionToSet) {
+    return null;
+  }
+
+  /**
+   * Returns whether the reader is at the end of the stream at the specified position
+   * 
+   * @param {Number} position
+   * @returns {Boolean}
+   * - true if the reader is at the end of the stream
+   * - false otherwise
+   */
+  atEnd(position) {}
+
+  /**
+   * Returns the size (number of bytes) of the reader.
+   */
+  size() {}
+
+  /**
+   * @example
+   *                 7  6                   0       n+7 n+6                 n
+   *               +===+=====================+     +---+---------------------+
+   * VarUInt field : 0 :         bits        :  …  | 1 |         bits        |
+   *               +===+=====================+     +---+---------------------+
+   * 
+   * @description
+   * VarUInt fields represent self-delimiting, variable-length unsigned integer values.
+   * These field formats are always used in a context that does not indicate the number of octets in the field;
+   * the last octet (and only the last octet) has its high-order bit set to terminate the field.
+   * 
+   * @returns {null | Object}
+   * The Object returned has the following properties:
+   * - numBytesRead
+   * - magnitude
+   */
+  readVarUInt() {
+    let totalNumBytesRead = 0;
+    let magnitude = 0;
+    let byte;
+
+    do {
+      byte = this.nextByte();
+
+      // not enough bytes available, reset reader position, propagate null
+      if (byte === null) {
+        this.skipBytes(-1 * totalNumBytesRead);
+        return null;
+      }
+
+      totalNumBytesRead++;
+      // 28+ bytes (4bytes read * 7bytes)
+      if (totalNumBytesRead === 5) {
+        magnitude = BigInt(magnitude);
+      }
+      if (totalNumBytesRead > 4) {
+        magnitude = (magnitude << 7n) | BigInt(byte & 0x7F);
+      } else {
+        magnitude = (magnitude << 7) | (byte & 0x7F);
+      }
+      // check the high-order bit
+    } while (!(byte & 0x80));
+
+    if (totalNumBytesRead > 4) {
+      if (magnitude > Number.MAX_SAFE_INTEGER) {
+        // TODO: pass the notice to the caller
+        let notice = `VarUInt > 4 bytes and magnitude (${magnitude}) > Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large VarUInts.`;
+      } else {
+        // TODO: pass the notice to the caller
+        let notice = `VarUInt > 4 bytes and magnitude (${magnitude}) <= Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large VarUInts.`;
+        magnitude = Number(magnitude);
+      }
+    }
+
+    return { numBytesRead: totalNumBytesRead, magnitude: magnitude };
+  };
+
+  /**
+   * @example
+   *             7                       0
+   *            +-------------------------+
+   * UInt field |          bits           |
+   *            +-------------------------+
+   *            :          bits           :
+   *            +=========================+
+   *                        ⋮
+   *            +=========================+
+   *            :          bits           :
+   *            +=========================+
+   *             n+7                     n
+   * 
+   * @description
+   * UInt fields represent fixed-length unsigned integer values.
+   * These field formats are always used in some context that clearly indicates the number of octets in the field.
+   * 
+   * UInts are sequences of octets, interpreted as big-endian.
+   * 
+   * @param {Number} length The length of the UInt to read.
+   * @returns {null | Object}
+   * The Object returned has the following properties:
+   * - numBytesRead
+   * - magnitude
+   */
+  readUInt(length) {
+    let totalNumBytesRead = 0;
+    let magnitude = 0;
+    let byte;
+
+    do {
+      byte = this.nextByte();
+
+      // not enough bytes available, reset reader position, propagate null
+      if (byte === null) {
+        this.skipBytes(-1 * totalNumBytesRead);
+        return null;
+      }
+
+      totalNumBytesRead++;
+      // 24+ bytes (3bytes read * 8bytes)
+      if (totalNumBytesRead === 4) {
+        magnitude = BigInt(magnitude);
+      }
+      if (totalNumBytesRead > 3) {
+        magnitude = (magnitude << 8n) | BigInt(byte);
+      } else {
+        magnitude = (magnitude << 8) | byte;
+      }
+    } while (totalNumBytesRead < length);
+
+    if (totalNumBytesRead > 4) {
+      if (magnitude > Number.MAX_SAFE_INTEGER) {
+        // TODO: pass the notice to the caller
+        let notice = `UInt > 4 bytes and magnitude (${magnitude}) > Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large UInts.`;
+      } else {
+        // TODO: pass the notice to the caller
+        let notice = `UInt > 4 bytes and magnitude (${magnitude}) <= Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large UInts.`;
+        magnitude = Number(magnitude);
+      }
+    }
+
+    return { numBytesRead: totalNumBytesRead, magnitude: magnitude };
+  };
+
+  /**
+   * @example
+   *                7   6  5               0       n+7 n+6                 n
+   *              +===+                           +---+
+   * VarInt field : 0 :       payload          …  | 1 |       payload
+   *              +===+                           +---+
+   *                  +---+-----------------+         +=====================+
+   *                  |   |   magnitude     |  …      :       magnitude     :
+   *                  +---+-----------------+         +=====================+
+   *                ^   ^                           ^
+   *                |   |                           |
+   *                |   +--sign                     +--end flag
+   *                +--end flag
+   * 
+   * @example
+   *                             7   6  5           0
+   *                           +---+---+-------------+
+   * single octet VarInt field | 1 |   |  magnitude  |
+   *                           +---+---+-------------+
+   *                                 ^
+   *                                 |
+   *                                 +--sign
+   * 
+   * @description
+   * VarInt fields represent self-delimiting, variable-length signed integer values.
+   * These field formats are always used in a context that does not indicate the number of octets in the field;
+   * the last octet (and only the last octet) has its high-order bit set to terminate the field.
+
+   * VarInts are sign-and-magnitude integers, like Ints. Their layout is complicated, as there is one special
+   * leading bit (the sign) and one special trailing bit (the terminator). In the above diagram, we put the two
+   * concepts on different layers.
+   * 
+   * The high-order bit in the top layer is an end-of-sequence marker. It must be set on the last octet in the
+   * representation and clear in all other octets. The second-highest order bit (0x40) is a sign flag in the first
+   * octet of the representation, but part of the extension bits for all other octets. For single-octet VarInt values,
+   * this collapses down to:
+   * 
+   * @returns {null | Object}
+   * The Object returned has the following properties:
+   * - numBytesRead
+   * - magnitude
+   * - isNegative
+   */
+  readVarInt () {
+    let totalNumBytesRead = 0;
+    let magnitude = 0;
+    let isNegative;
+    let byte;
+
+    do {
+      byte = this.nextByte();
+
+      // not enough bytes available, reset reader position, propagate null
+      if (byte === null) { 
+        this.skipBytes(-1 * totalNumBytesRead);
+        return null;
+      }
+
+      totalNumBytesRead++;
+      // 28+ bytes (4bytes read * 7bytes)
+      if (totalNumBytesRead === 5) {
+        magnitude = BigInt(magnitude);
+      }
+      if (totalNumBytesRead === 1) {
+        isNegative = ((byte & 0x40) === 0) ? false : true;
+        magnitude = byte & 0x3F;
+      } else if (totalNumBytesRead > 4) {
+        magnitude = (magnitude << 7n) | BigInt(byte & 0x7F);
+      } else {
+        magnitude = (magnitude << 7) | (byte & 0x7F);
+      }
+      // check the high-order bit
+    } while (!(byte & 0x80));
+
+    if (totalNumBytesRead > 4) {
+      if (magnitude > Number.MAX_SAFE_INTEGER) {
+        // TODO: pass the notice to the caller
+        let notice = `VarInt > 4 bytes and magnitude (${magnitude}) > Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large VarInts.`;
+      } else {
+        // TODO: pass the notice to the caller
+        let notice = `VarInt > 4 bytes and magnitude (${magnitude}) <= Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large VarInts.`;
+        magnitude = Number(magnitude);
+      }
+    }
+
+    return { numBytesRead: totalNumBytesRead, magnitude: ((isNegative === true) ? -magnitude : magnitude),
+            isNegative: isNegative };
+  };
+  
+  /**
+   * @example
+   *              7  6                   0
+   *            +---+---------------------+
+   * Int field  |   |      bits           |
+   *            +---+---------------------+
+   *              ^
+   *              |
+   *              +--sign
+   *            +=========================+
+   *            :          bits           :
+   *            +=========================+
+   *                        ⋮
+   *            +=========================+
+   *            :          bits           :
+   *            +=========================+
+   *             n+7                     n
+   * 
+   * @description
+   * Int fields represent fixed-length signed integer values.
+   * These field formats are always used in some context that clearly indicates the number of octets in the field.
+   * 
+   * Ints are sequences of octets, interpreted as sign-and-magnitude big endian integers (with the sign on the
+   * highest-order bit of the first octet). This means that the representations of 123456 and -123456 should only
+   * differ in their sign bit.
+   * 
+   * @param {Number} length The length of the Int to read.
+   * @returns {null | Object}
+   * The Object returned has the following properties:
+   * - numBytesRead
+   * - magnitude
+   * - isNegative
+   */
+  readInt (length) {
+    let totalNumBytesRead = 0;
+    let magnitude = 0;
+    let isNegative;
+    let byte;
+
+    do {
+      byte = this.nextByte();
+
+      // not enough bytes available, reset reader position, propagate null
+      if (byte === null) { 
+        this.skipBytes(-1 * totalNumBytesRead);
+        return null;
+      }
+
+      totalNumBytesRead++;
+      // 24+ bytes (3bytes read * 8bytes - 1bit)
+      if (totalNumBytesRead === 4) {
+        magnitude = BigInt(magnitude);
+      }
+      if (totalNumBytesRead === 1) {
+        isNegative = ((byte & 0x80) === 0) ? false : true;
+        magnitude = (magnitude << 7) | (byte & 0x7F);
+      }
+      else if (totalNumBytesRead > 3) {
+        magnitude = (magnitude << 8n) | BigInt(byte);
+      } else {
+        magnitude = (magnitude << 8) | byte;
+      }
+    } while (totalNumBytesRead < length);
+
+    if (totalNumBytesRead > 4) {
+      if (magnitude > Number.MAX_SAFE_INTEGER) {
+        // TODO: pass the notice to the caller
+        let notice = `Int > 4 bytes and magnitude (${magnitude}) > Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large Ints.`;
+      } else {
+        // TODO: pass the notice to the caller
+        let notice = `Int > 4 bytes and magnitude (${magnitude}) <= Number.MAX_SAFE_INTEGER (${Number.MAX_SAFE_INTEGER}); not all readers support large Ints.`;
+        magnitude = Number(magnitude);
+      }
+    }
+
+    return { numBytesRead: totalNumBytesRead, magnitude: ((isNegative === true) ? -magnitude : magnitude),
+            isNegative: isNegative };
+  };
+};
+
+exports.ByteReader = ByteReader;

--- a/src/core/IonTypes.js
+++ b/src/core/IonTypes.js
@@ -1,0 +1,69 @@
+'use strict';
+
+/**
+ * All of the Ion types plus internal tyoes.
+ */
+const IonTypes = {
+  "null": 0,
+  "bool": 1,
+  "int+": 2,
+  "int-": 3,
+  "float": 4,
+  "decimal": 5,
+  "timestamp": 6,
+  "symbol": 7,
+  "string": 8,
+  "clob": 9,
+  "blob": 10,
+  "list": 11,
+  "sexp": 12,
+  "struct": 13,
+  "annotation": 14,
+  "reserved": 15,
+  "bvm": 16,
+  "nop": 17,
+  "numTypes": 18,
+
+  /**
+   * Returns whether the specified type is a container type
+   * 
+   * @param {Number} type 
+   * @returns {Boolean}
+   */
+  isContainer: function (type) {
+    return (type === this["list"] || type === this["sexp"] || type === this["struct"]) ? true : false;
+  },
+  /**
+   * Returns whether the specified type is a scalar type
+   * 
+   * @param {Number} type 
+   * @returns {Boolean}
+   */
+  isScalar: function (type) {
+    return (type === this["null"] || type === this["bool"] || type === this["int+"] || type === this["int-"] ||
+            type === this["float"] || type === this["decimal"] || type === this["timestamp"] || 
+            type === this["symbol"] || type === this["string"] || type === this["clob"] || type === this["blob"]
+           ) ? true : false;
+  },
+  /**
+   * Returns the name of the specified type
+   * 
+   * @param {Number} type 
+   * @returns {String}
+   */
+  nameFromType: function (type) {
+    return IonTypesReverse[type];
+  }
+};
+
+/**
+ * A reverse mapping of the IonTypes defined above.
+ * ie. IonTypesReverse[0] = "null"
+ */
+const IonTypesReverse = new Array(IonTypes["numTypes"]);
+for (let [key, value] of Object.entries(IonTypes)) {
+  if (key === "numTypes") { continue; }
+  IonTypesReverse[value] = key;
+}
+
+exports.IonTypes = IonTypes;

--- a/src/core/TypeDescriptorReader.js
+++ b/src/core/TypeDescriptorReader.js
@@ -1,0 +1,488 @@
+'use strict';
+
+const br = require('./ByteReader');
+const IonTypes = require('./IonTypes').IonTypes;
+
+/**
+ * Reads the type descriptor
+ * 
+ * A value consists of a one-octet type descriptor, possibly followed by a length in octets, possibly followed
+ * by a representation.
+ * 
+ *        7       4 3       0
+ *       +---------+---------+
+ * value |    T    |    L    |
+ *       +---------+---------+======+
+ *       :     length [VarUInt]     :
+ *       +==========================+
+ *       :      representation      :
+ *       +==========================+
+ * The type descriptor octet has two subfields: a four-bit type code T, and a four-bit length L.
+ * 
+ * Each value of T identifies the format of the representation, and generally (though not always) identifies an
+ * Ion datatype. Each type code T defines the semantics of its length field L as described below.
+ * 
+ * The length value – the number of octets in the representation field(s) – is encoded in L and/or length fields,
+ * depending on the magnitude and on some particulars of the actual type. The length field is empty (taking up no
+ * octets in the message) if we can store the length value inside L itself. If the length field is not empty,
+ * then it is a single VarUInt field. The representation may also be empty (no octets) in some cases,
+ * as detailed below.
+ * 
+ * Unless otherwise defined, the length of the representation is encoded as follows:
+ *   If the value is null (for that type), then L is set to 15.
+ *   If the representation is less than 14 bytes long, then L is set to the length, and the length field is omitted.
+ *   If the representation is at least 14 bytes long, then L is set to 14, and the length field is set to the
+ *     representation length, encoded as a VarUInt field.
+ */
+class TypeDescriptorReader {
+
+  /**
+   * Mapping of all 256 (1 byte) Ion 1.0 type descriptors
+   */
+  #typeDescriptors_1_0 = [
+    /* 0x00 - nop padding         */ () => ({ type: IonTypes["nop"], length: 0, isNull: false }),
+    /* 0x01 - nop padding         */ () => ({ type: IonTypes["nop"], length: 1, isNull: false }), 
+    /* 0x02 - nop padding         */ () => ({ type: IonTypes["nop"], length: 2, isNull: false }), 
+    /* 0x03 - nop padding         */ () => ({ type: IonTypes["nop"], length: 3, isNull: false }),
+    /* 0x04 - nop padding         */ () => ({ type: IonTypes["nop"], length: 4, isNull: false }),
+    /* 0x05 - nop padding         */ () => ({ type: IonTypes["nop"], length: 5, isNull: false }),
+    /* 0x06 - nop padding         */ () => ({ type: IonTypes["nop"], length: 6, isNull: false }),
+    /* 0x07 - nop padding         */ () => ({ type: IonTypes["nop"], length: 7, isNull: false }),
+    /* 0x08 - nop padding         */ () => ({ type: IonTypes["nop"], length: 8, isNull: false }),
+    /* 0x09 - nop padding         */ () => ({ type: IonTypes["nop"], length: 9, isNull: false }),
+    /* 0x0a - nop padding         */ () => ({ type: IonTypes["nop"], length: 10, isNull: false }),
+    /* 0x0b - nop padding         */ () => ({ type: IonTypes["nop"], length: 11, isNull: false }),
+    /* 0x0c - nop padding         */ () => ({ type: IonTypes["nop"], length: 12, isNull: false }),
+    /* 0x0d - nop padding         */ () => ({ type: IonTypes["nop"], length: 13, isNull: false }),
+    /* 0x0e - nop padding         */ () => ({ type: IonTypes["nop"], length: 14, isNull: false }), // VarUInt
+    /* 0x0f - null (null)         */ () => ({ type: IonTypes["null"], length: 0, isNull: true }),
+    /* 0x10 - bool - false        */ () => ({ type: IonTypes["bool"], length: 0, isNull: false, bool: false }),
+    /* 0x11 - bool - true         */ () => ({ type: IonTypes["bool"], length: 0, isNull: false, bool: true }),
+    /* 0x12 - invalid bool        */ () => this.#typeDescriptorError("0x12"),
+    /* 0x13 - invalid bool        */ () => this.#typeDescriptorError("0x13"),
+    /* 0x14 - invalid bool        */ () => this.#typeDescriptorError("0x14"),
+    /* 0x15 - invalid bool        */ () => this.#typeDescriptorError("0x15"),
+    /* 0x16 - invalid bool        */ () => this.#typeDescriptorError("0x16"),
+    /* 0x17 - invalid bool        */ () => this.#typeDescriptorError("0x17"),
+    /* 0x18 - invalid bool        */ () => this.#typeDescriptorError("0x18"),
+    /* 0x19 - invalid bool        */ () => this.#typeDescriptorError("0x19"),
+    /* 0x1a - invalid bool        */ () => this.#typeDescriptorError("0x1a"),
+    /* 0x1b - invalid bool        */ () => this.#typeDescriptorError("0x1b"),
+    /* 0x1c - invalid bool        */ () => this.#typeDescriptorError("0x1c"),
+    /* 0x1d - invalid bool        */ () => this.#typeDescriptorError("0x1d"),
+    /* 0x1e - invalid bool        */ () => this.#typeDescriptorError("0x1e"),
+    /* 0x1f - bool (null)         */ () => ({ type: IonTypes["bool"], length: 0, isNull: true }),
+    /* 0x20 - int (pos) - 0       */ () => ({ type: IonTypes["int+"], length: 0, isNull: false }),
+    /* 0x21 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 1, isNull: false }),
+    /* 0x22 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 2, isNull: false }),
+    /* 0x23 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 3, isNull: false }),
+    /* 0x24 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 4, isNull: false }),
+    /* 0x25 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 5, isNull: false }),
+    /* 0x26 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 6, isNull: false }),
+    /* 0x27 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 7, isNull: false }),
+    /* 0x28 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 8, isNull: false }),
+    /* 0x29 - int (pos)           */ () => ({ type: IonTypes["int+"], length: 9, isNull: false }),
+    /* 0x2a - int (pos)           */ () => ({ type: IonTypes["int+"], length: 10, isNull: false }),
+    /* 0x2b - int (pos)           */ () => ({ type: IonTypes["int+"], length: 11, isNull: false }),
+    /* 0x2c - int (pos)           */ () => ({ type: IonTypes["int+"], length: 12, isNull: false }),
+    /* 0x2d - int (pos)           */ () => ({ type: IonTypes["int+"], length: 13, isNull: false }),
+    /* 0x2e - int (pos) (L >= 14) */ () => ({ type: IonTypes["int+"], length: 14, isNull: false }), // VarUInt
+    /* 0x2f - int (pos) (null)    */ () => ({ type: IonTypes["int+"], length: 0, isNull: true }), // NOTE: no magnitude
+    /* 0x30 - invalid int         */ () => this.#typeDescriptorError("0x30"),
+    /* 0x31 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 1, isNull: false }),
+    /* 0x32 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 2, isNull: false }),
+    /* 0x33 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 3, isNull: false }),
+    /* 0x34 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 4, isNull: false }),
+    /* 0x35 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 5, isNull: false }),
+    /* 0x36 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 6, isNull: false }),
+    /* 0x37 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 7, isNull: false }),
+    /* 0x38 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 8, isNull: false }),
+    /* 0x39 - int (neg)           */ () => ({ type: IonTypes["int-"], length: 9, isNull: false }),
+    /* 0x3a - int (neg)           */ () => ({ type: IonTypes["int-"], length: 10, isNull: false }),
+    /* 0x3b - int (neg)           */ () => ({ type: IonTypes["int-"], length: 11, isNull: false }),
+    /* 0x3c - int (neg)           */ () => ({ type: IonTypes["int-"], length: 12, isNull: false }),
+    /* 0x3d - int (neg)           */ () => ({ type: IonTypes["int-"], length: 13, isNull: false }),
+    /* 0x3e - int (neg) (L >= 14) */ () => ({ type: IonTypes["int-"], length: 14, isNull: false }), // VarUInt
+    /* 0x3f - int (neg) (null)    */ () => ({ type: IonTypes["int-"], length: 0, isNull: true }), // NOTE: no magnitude
+    /* 0x40 - float - 0e0         */ () => ({ type: IonTypes["float"], length: 0, isNull: false }),
+    /* 0x41 - invalid float       */ () => this.#typeDescriptorError("0x41"),
+    /* 0x42 - invalid float       */ () => this.#typeDescriptorError("0x42"), // reserved for 16 bit floats
+    /* 0x43 - invalid float       */ () => this.#typeDescriptorError("0x43"),
+    /* 0x44 - float (32 bits)     */ () => ({ type: IonTypes["float"], length: 4, isNull: false }),
+    /* 0x45 - invalid float       */ () => this.#typeDescriptorError("0x45"),
+    /* 0x46 - invalid float       */ () => this.#typeDescriptorError("0x46"),
+    /* 0x47 - invalid float       */ () => this.#typeDescriptorError("0x47"),
+    /* 0x48 - float (64 bits)     */ () => ({ type: IonTypes["float"], length: 8, isNull: false }),
+    /* 0x49 - invalid float       */ () => this.#typeDescriptorError("0x49"),
+    /* 0x4a - invalid float       */ () => this.#typeDescriptorError("0x4a"),
+    /* 0x4b - invalid float       */ () => this.#typeDescriptorError("0x4b"),
+    /* 0x4c - invalid float       */ () => this.#typeDescriptorError("0x4c"),
+    /* 0x4d - invalid float       */ () => this.#typeDescriptorError("0x4d"),
+    /* 0x4e - invalid float       */ () => this.#typeDescriptorError("0x4e"),
+    /* 0x4f - float (null)        */ () => ({ type: IonTypes["float"], length: 0, isNull: true }),
+    /* 0x50 - decimal - 0d0       */ () => ({ type: IonTypes["decimal"], length: 0, isNull: false }),
+    /* 0x51 - decimal             */ () => ({ type: IonTypes["decimal"], length: 1, isNull: false }),
+    /* 0x52 - decimal             */ () => ({ type: IonTypes["decimal"], length: 2, isNull: false }),
+    /* 0x53 - decimal             */ () => ({ type: IonTypes["decimal"], length: 3, isNull: false }),
+    /* 0x54 - decimal             */ () => ({ type: IonTypes["decimal"], length: 4, isNull: false }),
+    /* 0x55 - decimal             */ () => ({ type: IonTypes["decimal"], length: 5, isNull: false }),
+    /* 0x56 - decimal             */ () => ({ type: IonTypes["decimal"], length: 6, isNull: false }),
+    /* 0x57 - decimal             */ () => ({ type: IonTypes["decimal"], length: 7, isNull: false }),
+    /* 0x58 - decimal             */ () => ({ type: IonTypes["decimal"], length: 8, isNull: false }),
+    /* 0x59 - decimal             */ () => ({ type: IonTypes["decimal"], length: 9, isNull: false }),
+    /* 0x5a - decimal             */ () => ({ type: IonTypes["decimal"], length: 10, isNull: false }),
+    /* 0x5b - decimal             */ () => ({ type: IonTypes["decimal"], length: 11, isNull: false }),
+    /* 0x5c - decimal             */ () => ({ type: IonTypes["decimal"], length: 12, isNull: false }),
+    /* 0x5d - decimal             */ () => ({ type: IonTypes["decimal"], length: 13, isNull: false }),
+    /* 0x5e - decimal (L >= 14)   */ () => ({ type: IonTypes["decimal"], length: 14, isNull: false }), // VarUInt
+    /* 0x5f - decimal (null)      */ () => ({ type: IonTypes["decimal"], length: 0, isNull: true }),
+    /* 0x60 - invalid timestamp   */ () => this.#typeDescriptorError("0x60"),
+    /* 0x61 - invalid timestamp   */ () => this.#typeDescriptorError("0x61"),
+    /* 0x62 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 2, isNull: false }),
+    /* 0x63 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 3, isNull: false }),
+    /* 0x64 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 4, isNull: false }),
+    /* 0x65 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 5, isNull: false }),
+    /* 0x66 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 6, isNull: false }),
+    /* 0x67 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 7, isNull: false }),
+    /* 0x68 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 8, isNull: false }),
+    /* 0x69 - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 9, isNull: false }),
+    /* 0x6a - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 10, isNull: false }),
+    /* 0x6b - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 11, isNull: false }),
+    /* 0x6c - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 12, isNull: false }),
+    /* 0x6d - timestamp           */ () => ({ type: IonTypes["timestamp"], length: 13, isNull: false }),
+    /* 0x6e - timestamp (L >= 14) */ () => ({ type: IonTypes["timestamp"], length: 14, isNull: false }), // VarUInt
+    /* 0x6f - timestamp (null)    */ () => ({ type: IonTypes["timestamp"], length: 0, isNull: true }),
+    /* 0x70 - symbol - $0 (SID0)  */ () => ({ type: IonTypes["symbol"], length: 0, isNull: false }),
+    /* 0x71 - symbol              */ () => ({ type: IonTypes["symbol"], length: 1, isNull: false }),
+    /* 0x72 - symbol              */ () => ({ type: IonTypes["symbol"], length: 2, isNull: false }),
+    /* 0x73 - symbol              */ () => ({ type: IonTypes["symbol"], length: 3, isNull: false }),
+    /* 0x74 - symbol              */ () => ({ type: IonTypes["symbol"], length: 4, isNull: false }),
+    /* 0x75 - symbol              */ () => ({ type: IonTypes["symbol"], length: 5, isNull: false }),
+    /* 0x76 - symbol              */ () => ({ type: IonTypes["symbol"], length: 6, isNull: false }),
+    /* 0x77 - symbol              */ () => ({ type: IonTypes["symbol"], length: 7, isNull: false }),
+    /* 0x78 - symbol              */ () => ({ type: IonTypes["symbol"], length: 8, isNull: false }),
+    /* 0x79 - symbol              */ () => ({ type: IonTypes["symbol"], length: 9, isNull: false }),
+    /* 0x7a - symbol              */ () => ({ type: IonTypes["symbol"], length: 10, isNull: false }),
+    /* 0x7b - symbol              */ () => ({ type: IonTypes["symbol"], length: 11, isNull: false }),
+    /* 0x7c - symbol              */ () => ({ type: IonTypes["symbol"], length: 12, isNull: false }),
+    /* 0x7d - symbol              */ () => ({ type: IonTypes["symbol"], length: 13, isNull: false }),
+    /* 0x7e - symbol (L >= 14)    */ () => ({ type: IonTypes["symbol"], length: 14, isNull: false }), // VarUInt
+    /* 0x7f - symbol (null)       */ () => ({ type: IonTypes["symbol"], length: 0, isNull: true }),
+    /* 0x80 - string - ""         */ () => ({ type: IonTypes["string"], length: 0, isNull: false }),
+    /* 0x81 - string              */ () => ({ type: IonTypes["string"], length: 1, isNull: false }),
+    /* 0x82 - string              */ () => ({ type: IonTypes["string"], length: 2, isNull: false }),
+    /* 0x83 - string              */ () => ({ type: IonTypes["string"], length: 3, isNull: false }),
+    /* 0x84 - string              */ () => ({ type: IonTypes["string"], length: 4, isNull: false }),
+    /* 0x85 - string              */ () => ({ type: IonTypes["string"], length: 5, isNull: false }),
+    /* 0x86 - string              */ () => ({ type: IonTypes["string"], length: 6, isNull: false }),
+    /* 0x87 - string              */ () => ({ type: IonTypes["string"], length: 7, isNull: false }),
+    /* 0x88 - string              */ () => ({ type: IonTypes["string"], length: 8, isNull: false }),
+    /* 0x89 - string              */ () => ({ type: IonTypes["string"], length: 9, isNull: false }),
+    /* 0x8a - string              */ () => ({ type: IonTypes["string"], length: 10, isNull: false }),
+    /* 0x8b - string              */ () => ({ type: IonTypes["string"], length: 11, isNull: false }),
+    /* 0x8c - string              */ () => ({ type: IonTypes["string"], length: 12, isNull: false }),
+    /* 0x8d - string              */ () => ({ type: IonTypes["string"], length: 13, isNull: false }),
+    /* 0x8e - string (L >= 14)    */ () => ({ type: IonTypes["string"], length: 14, isNull: false }), // VarUInt
+    /* 0x8f - string (null)       */ () => ({ type: IonTypes["string"], length: 0, isNull: true }),
+    /* 0x90 - clob                */ () => ({ type: IonTypes["clob"], length: 0, isNull: false }), // 0 length clobs are legal
+    /* 0x91 - clob                */ () => ({ type: IonTypes["clob"], length: 1, isNull: false }),
+    /* 0x92 - clob                */ () => ({ type: IonTypes["clob"], length: 2, isNull: false }),
+    /* 0x93 - clob                */ () => ({ type: IonTypes["clob"], length: 3, isNull: false }),
+    /* 0x94 - clob                */ () => ({ type: IonTypes["clob"], length: 4, isNull: false }),
+    /* 0x95 - clob                */ () => ({ type: IonTypes["clob"], length: 5, isNull: false }),
+    /* 0x96 - clob                */ () => ({ type: IonTypes["clob"], length: 6, isNull: false }),
+    /* 0x97 - clob                */ () => ({ type: IonTypes["clob"], length: 7, isNull: false }),
+    /* 0x98 - clob                */ () => ({ type: IonTypes["clob"], length: 8, isNull: false }),
+    /* 0x99 - clob                */ () => ({ type: IonTypes["clob"], length: 9, isNull: false }),
+    /* 0x9a - clob                */ () => ({ type: IonTypes["clob"], length: 10, isNull: false }),
+    /* 0x9b - clob                */ () => ({ type: IonTypes["clob"], length: 11, isNull: false }),
+    /* 0x9c - clob                */ () => ({ type: IonTypes["clob"], length: 12, isNull: false }),
+    /* 0x9d - clob                */ () => ({ type: IonTypes["clob"], length: 13, isNull: false }),
+    /* 0x9e - clob (L >= 14)      */ () => ({ type: IonTypes["clob"], length: 14, isNull: false }), // VarUInt
+    /* 0x9f - clob (null)         */ () => ({ type: IonTypes["clob"], length: 0, isNull: true }),
+    /* 0xa0 - blob                */ () => ({ type: IonTypes["blob"], length: 0, isNull: false }), // 0 length blobs are legal
+    /* 0xa1 - blob                */ () => ({ type: IonTypes["blob"], length: 1, isNull: false }),
+    /* 0xa2 - blob                */ () => ({ type: IonTypes["blob"], length: 2, isNull: false }),
+    /* 0xa3 - blob                */ () => ({ type: IonTypes["blob"], length: 3, isNull: false }),
+    /* 0xa4 - blob                */ () => ({ type: IonTypes["blob"], length: 4, isNull: false }),
+    /* 0xa5 - blob                */ () => ({ type: IonTypes["blob"], length: 5, isNull: false }),
+    /* 0xa6 - blob                */ () => ({ type: IonTypes["blob"], length: 6, isNull: false }),
+    /* 0xa7 - blob                */ () => ({ type: IonTypes["blob"], length: 7, isNull: false }),
+    /* 0xa8 - blob                */ () => ({ type: IonTypes["blob"], length: 8, isNull: false }),
+    /* 0xa9 - blob                */ () => ({ type: IonTypes["blob"], length: 9, isNull: false }),
+    /* 0xaa - blob                */ () => ({ type: IonTypes["blob"], length: 10, isNull: false }),
+    /* 0xab - blob                */ () => ({ type: IonTypes["blob"], length: 11, isNull: false }),
+    /* 0xac - blob                */ () => ({ type: IonTypes["blob"], length: 12, isNull: false }),
+    /* 0xad - blob                */ () => ({ type: IonTypes["blob"], length: 13, isNull: false }),
+    /* 0xae - blob (L >= 14)      */ () => ({ type: IonTypes["blob"], length: 14, isNull: false }), // VarUInt
+    /* 0xaf - blob (null)         */ () => ({ type: IonTypes["blob"], length: 0, isNull: true }),
+    /* 0xb0 - list - []           */ () => ({ type: IonTypes["list"], length: 0, isNull: false }),
+    /* 0xb1 - list                */ () => ({ type: IonTypes["list"], length: 1, isNull: false }),
+    /* 0xb2 - list                */ () => ({ type: IonTypes["list"], length: 2, isNull: false }),
+    /* 0xb3 - list                */ () => ({ type: IonTypes["list"], length: 3, isNull: false }),
+    /* 0xb4 - list                */ () => ({ type: IonTypes["list"], length: 4, isNull: false }),
+    /* 0xb5 - list                */ () => ({ type: IonTypes["list"], length: 5, isNull: false }),
+    /* 0xb6 - list                */ () => ({ type: IonTypes["list"], length: 6, isNull: false }),
+    /* 0xb7 - list                */ () => ({ type: IonTypes["list"], length: 7, isNull: false }),
+    /* 0xb8 - list                */ () => ({ type: IonTypes["list"], length: 8, isNull: false }),
+    /* 0xb9 - list                */ () => ({ type: IonTypes["list"], length: 9, isNull: false }),
+    /* 0xba - list                */ () => ({ type: IonTypes["list"], length: 10, isNull: false }),
+    /* 0xbb - list                */ () => ({ type: IonTypes["list"], length: 11, isNull: false }),
+    /* 0xbc - list                */ () => ({ type: IonTypes["list"], length: 12, isNull: false }),
+    /* 0xbd - list                */ () => ({ type: IonTypes["list"], length: 13, isNull: false }),
+    /* 0xbe - list (L >= 14)      */ () => ({ type: IonTypes["list"], length: 14, isNull: false }), // VarUInt
+    /* 0xbf - list (null)         */ () => ({ type: IonTypes["list"], length: 0, isNull: true }),
+    /* 0xc0 - sexp - ()           */ () => ({ type: IonTypes["sexp"], length: 0, isNull: false }),
+    /* 0xc1 - sexp                */ () => ({ type: IonTypes["sexp"], length: 1, isNull: false }),
+    /* 0xc2 - sexp                */ () => ({ type: IonTypes["sexp"], length: 2, isNull: false }),
+    /* 0xc3 - sexp                */ () => ({ type: IonTypes["sexp"], length: 3, isNull: false }),
+    /* 0xc4 - sexp                */ () => ({ type: IonTypes["sexp"], length: 4, isNull: false }),
+    /* 0xc5 - sexp                */ () => ({ type: IonTypes["sexp"], length: 5, isNull: false }),
+    /* 0xc6 - sexp                */ () => ({ type: IonTypes["sexp"], length: 6, isNull: false }),
+    /* 0xc7 - sexp                */ () => ({ type: IonTypes["sexp"], length: 7, isNull: false }),
+    /* 0xc8 - sexp                */ () => ({ type: IonTypes["sexp"], length: 8, isNull: false }),
+    /* 0xc9 - sexp                */ () => ({ type: IonTypes["sexp"], length: 9, isNull: false }),
+    /* 0xca - sexp                */ () => ({ type: IonTypes["sexp"], length: 10, isNull: false }),
+    /* 0xcb - sexp                */ () => ({ type: IonTypes["sexp"], length: 11, isNull: false }),
+    /* 0xcc - sexp                */ () => ({ type: IonTypes["sexp"], length: 12, isNull: false }),
+    /* 0xcd - sexp                */ () => ({ type: IonTypes["sexp"], length: 13, isNull: false }),
+    /* 0xce - sexp (L >= 14)      */ () => ({ type: IonTypes["sexp"], length: 14, isNull: false }), // VarUInt
+    /* 0xcf - sexp (null)         */ () => ({ type: IonTypes["sexp"], length: 0, isNull: true }),
+    /* 0xd0 - struct - {}         */ () => ({ type: IonTypes["struct"], length: 0, isNull: false }),
+    /* 0xd1 - struct              */ () => ({ type: IonTypes["struct"], length: 14, isNull: false }), // sorted, VarUInt
+    /* 0xd2 - struct              */ () => ({ type: IonTypes["struct"], length: 2, isNull: false }),
+    /* 0xd3 - struct              */ () => ({ type: IonTypes["struct"], length: 3, isNull: false }),
+    /* 0xd4 - struct              */ () => ({ type: IonTypes["struct"], length: 4, isNull: false }),
+    /* 0xd5 - struct              */ () => ({ type: IonTypes["struct"], length: 5, isNull: false }),
+    /* 0xd6 - struct              */ () => ({ type: IonTypes["struct"], length: 6, isNull: false }),
+    /* 0xd7 - struct              */ () => ({ type: IonTypes["struct"], length: 7, isNull: false }),
+    /* 0xd8 - struct              */ () => ({ type: IonTypes["struct"], length: 8, isNull: false }),
+    /* 0xd9 - struct              */ () => ({ type: IonTypes["struct"], length: 9, isNull: false }),
+    /* 0xda - struct              */ () => ({ type: IonTypes["struct"], length: 10, isNull: false }),
+    /* 0xdb - struct              */ () => ({ type: IonTypes["struct"], length: 11, isNull: false }),
+    /* 0xdc - struct              */ () => ({ type: IonTypes["struct"], length: 12, isNull: false }),
+    /* 0xdd - struct              */ () => ({ type: IonTypes["struct"], length: 13, isNull: false }),
+    /* 0xde - struct (L >= 14)    */ () => ({ type: IonTypes["struct"], length: 14, isNull: false }), // VarUInt
+    /* 0xdf - struct (null)       */ () => ({ type: IonTypes["struct"], length: 0, isNull: true }),
+    /* 0xe0 - bvm                 */ () => ({ type: IonTypes["bvm"], length: 3, isNull: false }),
+    /* 0xe1 - invalid annotation  */ () => this.#typeDescriptorError("0xe1"),
+    /* 0xe2 - invalid annotation  */ () => this.#typeDescriptorError("0xe2"),
+    /* 0xe3 - annotation          */ () => ({ type: IonTypes["annotation"], length: 3, isNull: false }),
+    /* 0xe4 - annotation          */ () => ({ type: IonTypes["annotation"], length: 4, isNull: false }),
+    /* 0xe5 - annotation          */ () => ({ type: IonTypes["annotation"], length: 5, isNull: false }),
+    /* 0xe6 - annotation          */ () => ({ type: IonTypes["annotation"], length: 6, isNull: false }),
+    /* 0xe7 - annotation          */ () => ({ type: IonTypes["annotation"], length: 7, isNull: false }),
+    /* 0xe8 - annotation          */ () => ({ type: IonTypes["annotation"], length: 8, isNull: false }),
+    /* 0xe9 - annotation          */ () => ({ type: IonTypes["annotation"], length: 9, isNull: false }),
+    /* 0xea - annotation          */ () => ({ type: IonTypes["annotation"], length: 10, isNull: false }),
+    /* 0xeb - annotation          */ () => ({ type: IonTypes["annotation"], length: 11, isNull: false }),
+    /* 0xec - annotation          */ () => ({ type: IonTypes["annotation"], length: 12, isNull: false }),
+    /* 0xed - annotation          */ () => ({ type: IonTypes["annotation"], length: 13, isNull: false }),
+    /* 0xee - annotation (L >= 14)*/ () => ({ type: IonTypes["annotation"], length: 14, isNull: false }), // VarUInt
+    /* 0xef - invalid annotation  */ () => this.#typeDescriptorError("0xef"), 
+    /* 0xf0 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf0"), 
+    /* 0xf1 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf1"), 
+    /* 0xf2 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf2"), 
+    /* 0xf3 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf3"),
+    /* 0xf4 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf4"),
+    /* 0xf5 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf5"),
+    /* 0xf6 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf6"),
+    /* 0xf7 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf7"),
+    /* 0xf8 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf8"),
+    /* 0xf9 - invalid (reserved)  */ () => this.#typeDescriptorError("0xf9"),
+    /* 0xfa - invalid (reserved)  */ () => this.#typeDescriptorError("0xfa"),
+    /* 0xfb - invalid (reserved)  */ () => this.#typeDescriptorError("0xfb"),
+    /* 0xfc - invalid (reserved)  */ () => this.#typeDescriptorError("0xfc"),
+    /* 0xfd - invalid (reserved)  */ () => this.#typeDescriptorError("0xfd"),
+    /* 0xfe - invalid (reserved)  */ () => this.#typeDescriptorError("0xfe"),
+    /* 0xff - invalid (reserved)  */ () => this.#typeDescriptorError("0xff")
+  ];
+
+  /**
+   * The byte reader source
+   */
+  #byteReader;
+
+  /**
+   * A VarUInt that holds the length of the current Ion element.
+   */
+  #varUIntLengthByte;
+
+  /**
+   * Error handling for invalid type descriptors.
+   * 
+   * @param {String} hexString
+   * @throws Error every time.
+   */
+  #typeDescriptorError = (hexString) => { 
+    // TODO: pass the error to the caller
+    const err = new Error(`Invalid Ion T/L pair ${hexString}.`);
+    throw err;
+  };
+
+  /**
+   * Requires a ByteReader.
+   * 
+   * @param {ByteReader} byteReader
+   * @throws Error if byteReader is not a ByteReader
+   */
+  constructor (byteReader) {
+    if (!(byteReader instanceof br.ByteReader)) {
+      // TODO: pass the error to the caller
+      const err = new Error("expected byteReader to be a ByteReader");
+      throw err;
+    }
+
+    this.#byteReader = byteReader;
+  }
+
+  /**
+   * Reads the type descriptor and optional (>14) length bytes
+   * 
+   * @param {Number} positionToSet
+   * - positionToSet is required to be a positive integer
+   * @param {String} context 
+   * context can have the following values:
+   * - "1_0" - the Ion data is expected to be Ion 1.0
+   * - "bvm" - a bvm is required before being able to read the data
+   * @throws Error if
+   * - positionToSet is not a positive integer
+   * - there is no byte to read
+   * - context is invalid
+   * - context is bvm and the bytes read are not a bvm
+   * @returns {null | Object}
+   * The Object returned has the following properties:
+   * - type
+   * - length
+   * - isNull
+   * - length (if VarUInt)
+   * - varUIntLength
+   * - isVarUInt
+   * - isSortedStruct
+   * - annotationsLength
+   * - annotationsVarUIntLength
+   * - majorVersion
+   * - minorVersion 
+   */
+  readTypeAndLength(positionToSet, context) {
+    if (!Number.isInteger(positionToSet) || positionToSet < 0) {
+      // TODO: pass the error to the caller
+      const err = new Error(`positionToSet is not a positive integer`);
+      throw err;
+    }
+
+    this.#byteReader.setPosition(positionToSet);
+
+    const typeAndLengthByte = this.#byteReader.nextByte();
+
+    // not enough bytes available, propagate null
+    if (typeAndLengthByte === null) {
+      return null;
+    }
+
+    if (typeAndLengthByte === undefined) {
+      // TODO: pass the error to the caller
+      const err = new Error(`typeAndLengthyByte is undefined`);
+      throw err;
+    }
+
+    let typeDescriptors;
+    let mustBeBVM = false;
+    switch (context) {
+      case "1_0":
+        typeDescriptors = this.#typeDescriptors_1_0;
+        break;
+      case "bvm":
+        typeDescriptors = this.#typeDescriptors_1_0;
+        mustBeBVM = true;
+        break;
+      default:
+        // TODO: pass the error to the caller
+        const err = new Error(`unknown context`);
+        throw err;
+        break;
+
+    }
+    const typeAndLength = typeDescriptors[typeAndLengthByte]();
+
+    if (typeAndLength.type === IonTypes["bvm"]) {
+      typeAndLength.majorVersion = this.#byteReader.nextByte();
+      typeAndLength.minorVersion = this.#byteReader.nextByte();
+      this.#byteReader.skipBytes(-2);
+    } else if (mustBeBVM === true) {
+      // TODO: pass the error to the caller
+      const err = new Error(`bvm not found`);
+      throw err;
+      return;
+    }
+
+    // Length 14 indicates that there is a VarUInt that contains the length
+    if (typeAndLength.length === 14) {
+      const varUIntInfo = this.#byteReader.readVarUInt();
+      
+      // not enough bytes available, reset reader position (typeAndLengthByte), propagate null
+      if (varUIntInfo === null) {
+        this.#byteReader.skipBytes(-1);
+        return null;
+      }
+
+      if (varUIntInfo.magnitude < 14) {
+        // TODO: pass the notice to the caller
+        const notice = "T/L pair has length and magnitude which could be represented without extra length byte";
+      }
+      if (typeof varUIntInfo.magnitude === 'bigint') {
+        typeAndLength.length = BigInt(varUIntInfo.numBytesRead) + varUIntInfo.magnitude;
+      } else {
+        typeAndLength.length = varUIntInfo.numBytesRead + varUIntInfo.magnitude;
+      }
+      typeAndLength.varUIntLength = varUIntInfo.numBytesRead;
+      typeAndLength.isVarUInt = true;
+
+      // sorted struct (0xD1)
+      if (typeAndLengthByte === 209) {
+        typeAndLength.isSortedStruct = true;
+      }
+    }
+
+    if (typeAndLength.type === IonTypes.annotation) {
+      const varUIntInfo = this.#byteReader.readVarUInt();
+
+      // not enough bytes available, reset reader position (typeAndLengthByte), propagate null
+      if (varUIntInfo === null) {
+        if ( typeAndLength.varUIntLength !== undefined) {
+          this.#byteReader.skipBytes(-1 * (1 + typeAndLength.varUIntLength));
+        } else {
+          this.#byteReader.skipBytes(-1);
+        }
+        return null;
+      }
+
+      typeAndLength.annotationsLength = varUIntInfo.magnitude;
+      typeAndLength.annotationsVarUIntLength = varUIntInfo.numBytesRead;
+    }
+
+    return typeAndLength;
+  }
+
+  /**
+   * Reads the field name at the specified position.
+   * 
+   * @param {Number} positionToSet
+   * @returns {Number} a SymbolID (VarUInt)
+   */
+  readFieldName(positionToSet) {
+    this.#byteReader.setPosition(positionToSet);
+    return this.#byteReader.readVarUInt();
+  }
+
+  /**
+   * Sets the reader to the specified position.
+   * 
+   * @param {Number} positionToSet
+   */
+  setPosition(positionToSet) {
+    this.#byteReader.setPosition(positionToSet);
+  }
+}
+
+exports.TypeDescriptorReader = TypeDescriptorReader;

--- a/src/core/TypeDescriptorReader.js
+++ b/src/core/TypeDescriptorReader.js
@@ -6,9 +6,11 @@ const IonTypes = require('./IonTypes').IonTypes;
 /**
  * Reads the type descriptor
  * 
+ * @summary
  * A value consists of a one-octet type descriptor, possibly followed by a length in octets, possibly followed
  * by a representation.
  * 
+ * @example
  *        7       4 3       0
  *       +---------+---------+
  * value |    T    |    L    |
@@ -17,6 +19,8 @@ const IonTypes = require('./IonTypes').IonTypes;
  *       +==========================+
  *       :      representation      :
  *       +==========================+
+ * 
+ * @description
  * The type descriptor octet has two subfields: a four-bit type code T, and a four-bit length L.
  * 
  * Each value of T identifies the format of the representation, and generally (though not always) identifies an

--- a/test/core/ByteBufferReader.spec.js
+++ b/test/core/ByteBufferReader.spec.js
@@ -1,0 +1,587 @@
+const assert = require('chai').assert;
+const bbr = require('../../src/core/ByteBufferReader');
+
+let bufferReader;
+
+const fixBigIntPrinting = function () {
+    // fix needed for node
+    // http://thecodebarbarian.com/an-overview-of-bigint-in-node-js.html#limitations
+    // from: https://github.com/sqlpad/sqlpad/issues/518
+    BigInt.prototype.toJSON = function() { return this.toString(); };
+};
+
+describe('ByteReader', function() {
+  beforeEach(function () {
+    bufferReader = new bbr.ByteBufferReader();
+    fixBigIntPrinting();
+  });
+  describe("readVarUInt()", function () {
+    it('should read a 1 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 127);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+    it('should read a 4 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 268435455);
+      assert.strictEqual(value.numBytesRead, 4);
+    });
+    it('should read a 5 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 5);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 34359738367);
+      assert.strictEqual(value.numBytesRead, 5);
+    });
+    it('should read a 14 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), 
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 316912650057057350374175801343n);
+      assert.strictEqual(value.numBytesRead, 14);
+    });
+  });
+  describe("readUInt()", function () {
+    it('should read a 1 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(1);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(1);
+      assert.strictEqual(value.magnitude, 128);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(1);
+      assert.strictEqual(value.magnitude, 255);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+    it('should read a 3 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(3);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(3);
+      assert.strictEqual(value.magnitude, 8390784);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(3);
+      assert.strictEqual(value.magnitude, 16777215);
+      assert.strictEqual(value.numBytesRead, 3);
+    });
+    it('should read a 4 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(4);
+      assert.strictEqual(value.magnitude, 0n);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(4);
+      assert.strictEqual(value.magnitude, 2148040712n);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(4);
+      assert.strictEqual(value.magnitude, 4294967295n);
+      assert.strictEqual(value.numBytesRead, 4);
+    });
+    it('should read a 14 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(14);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16),
+         parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16),
+         parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16),
+         parseInt('0x80', 16), parseInt('0x08', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(14);
+      assert.strictEqual(value.magnitude, 2596821878924811327576341614198792n);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(14);
+      assert.strictEqual(value.magnitude, 5192296858534827628530496329220095n);
+      assert.strictEqual(value.numBytesRead, 14);
+    });
+  });
+  describe("readVarInt()", function () {
+    it('should read a 1 byte VarInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xC0', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xBF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, 63);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, -63);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+  });
+  it('should read a 3 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 3);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 1048575);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 3);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 3);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -1048575);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 3);
+  });
+  it('should read a 4 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 4);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 134217727);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 4);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 4);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -134217727);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 4);
+  });
+  it('should read a 5 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 5);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 17179869183);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 5);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 5);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -17179869183);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 5);
+  });
+  it('should read a 14 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 14);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 158456325028528675187087900671n);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 14);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 14);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -158456325028528675187087900671n);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 14);
+  });
+  describe("readInt()", function () {
+    it('should read a 1 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, 127);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, -127);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+    it('should read a 3 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, 8388607);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, -8388607);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 3);
+    });
+    it('should read a 4 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      // explicitly test both -0n and 0n to show that BigInt does not differentiate between the two
+      assert.strictEqual(value.magnitude, -0n);
+      assert.strictEqual(value.magnitude, 0n);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      assert.strictEqual(value.magnitude, 2147483647n);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      // explicitly test both -0n and 0n to show that BigInt does not differentiate between the two
+      assert.strictEqual(value.magnitude, -0n);
+      assert.strictEqual(value.magnitude, 0n);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      assert.strictEqual(value.magnitude, -2147483647n);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 4);
+    });
+    it('should read a 14 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, 2596148429267413814265248164610047n);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, -2596148429267413814265248164610047n);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 14);
+    });
+  });
+});

--- a/test/core/ByteReader.spec.js
+++ b/test/core/ByteReader.spec.js
@@ -1,0 +1,590 @@
+const assert = require('chai').assert;
+const bbr = require('../../src/core/ByteBufferReader');
+
+let bufferReader;
+
+const fixBigIntPrinting = function () {
+    // fix needed for node
+    // http://thecodebarbarian.com/an-overview-of-bigint-in-node-js.html#limitations
+    // from: https://github.com/sqlpad/sqlpad/issues/518
+    BigInt.prototype.toJSON = function() { return this.toString(); };
+};
+
+describe('ByteReader', function() {
+  beforeEach(function () {
+    bufferReader = new bbr.ByteBufferReader();
+  });
+  describe("readVarUInt()", function () {
+    it('should read a 1 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 127);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+    it('should read a 4 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 268435455);
+      assert.strictEqual(value.numBytesRead, 4);
+    });
+    it('should read a 5 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 5);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 34359738367);
+      assert.strictEqual(value.numBytesRead, 5);
+    });
+    it('should read a 14 byte VarUInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), 
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      fixBigIntPrinting();
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarUInt();
+      assert.strictEqual(value.magnitude, 316912650057057350374175801343n);
+      assert.strictEqual(value.numBytesRead, 14);
+    });
+  });
+  describe("readUInt()", function () {
+    it('should read a 1 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(1);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(1);
+      assert.strictEqual(value.magnitude, 128);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(1);
+      assert.strictEqual(value.magnitude, 255);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+    it('should read a 3 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(3);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(3);
+      assert.strictEqual(value.magnitude, 8390784);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(3);
+      assert.strictEqual(value.magnitude, 16777215);
+      assert.strictEqual(value.numBytesRead, 3);
+    });
+    it('should read a 4 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(4);
+      assert.strictEqual(value.magnitude, 0n);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(4);
+      assert.strictEqual(value.magnitude, 2148040712n);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(4);
+      assert.strictEqual(value.magnitude, 4294967295n);
+      assert.strictEqual(value.numBytesRead, 4);
+    });
+    it('should read a 14 byte UInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(14);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16),
+         parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16),
+         parseInt('0x80', 16), parseInt('0x08', 16), parseInt('0x80', 16), parseInt('0x08', 16),
+         parseInt('0x80', 16), parseInt('0x08', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(14);
+      assert.strictEqual(value.magnitude, 2596821878924811327576341614198792n);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readUInt(14);
+      assert.strictEqual(value.magnitude, 5192296858534827628530496329220095n);
+      assert.strictEqual(value.numBytesRead, 14);
+    });
+  });
+  describe("readVarInt()", function () {
+    it('should read a 1 byte VarInt', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xC0', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xBF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, 63);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readVarInt();
+      assert.strictEqual(value.magnitude, -63);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+  });
+  it('should read a 3 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 3);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 1048575);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 3);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 3);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -1048575);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 3);
+  });
+  it('should read a 4 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 4);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 134217727);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 4);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 4);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -134217727);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 4);
+  });
+  it('should read a 5 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 5);
+
+    fixBigIntPrinting();
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 17179869183);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 5);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 5);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -17179869183);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 5);
+  });
+  it('should read a 14 byte VarInt', function() {
+    let value;
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 0);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 14);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x3F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, 158456325028528675187087900671n);
+    assert.strictEqual(value.isNegative, false);
+    assert.strictEqual(value.numBytesRead, 14);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x40', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+       parseInt('0x00', 16), parseInt('0x80', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -0);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 14);
+
+    bufferReader.loadBuffer(new Uint8Array(
+      [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+       parseInt('0x7F', 16), parseInt('0xFF', 16)]
+    ));
+    bufferReader.setPosition(0);
+    value = bufferReader.readVarInt();
+    assert.strictEqual(value.magnitude, -158456325028528675187087900671n);
+    assert.strictEqual(value.isNegative, true);
+    assert.strictEqual(value.numBytesRead, 14);
+  });
+  describe("readInt()", function () {
+    it('should read a 1 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, 127);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(1);
+      assert.strictEqual(value.magnitude, -127);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 1);
+    });
+    it('should read a 3 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, 0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, 8388607);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 3);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(3);
+      assert.strictEqual(value.magnitude, -8388607);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 3);
+    });
+    it('should read a 4 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      // explicitly test both -0n and 0n to show that BigInt does not differentiate between the two
+      assert.strictEqual(value.magnitude, -0n);
+      assert.strictEqual(value.magnitude, 0n);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      assert.strictEqual(value.magnitude, 2147483647n);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      // explicitly test both -0n and 0n to show that BigInt does not differentiate between the two
+      assert.strictEqual(value.magnitude, -0n);
+      assert.strictEqual(value.magnitude, 0n);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 4);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(4);
+      assert.strictEqual(value.magnitude, -2147483647n);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 4);
+    });
+    it('should read a 14 byte Int', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, 2596148429267413814265248164610047n);
+      assert.strictEqual(value.isNegative, false);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16),
+         parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, -0);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 14);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      bufferReader.setPosition(0);
+      value = bufferReader.readInt(14);
+      assert.strictEqual(value.magnitude, -2596148429267413814265248164610047n);
+      assert.strictEqual(value.isNegative, true);
+      assert.strictEqual(value.numBytesRead, 14);
+    });
+  });
+});

--- a/test/core/TypeDescriptorReader.spec.js
+++ b/test/core/TypeDescriptorReader.spec.js
@@ -1,0 +1,425 @@
+const assert = require('chai').assert;
+const tdr = require("../../src/core/TypeDescriptorReader");
+const br = require('../../src/core/ByteReader');
+const types = require('../../src/core/IonTypes');
+let tdReader;
+
+const createReader = (reader) => {
+  return new tdr.TypeDescriptorReader(reader);
+};
+
+const createSingleUseByteReader = (hexToTest) => {
+  const buf = new Uint8Array(hexToTest);
+  let pos = 0;
+  const byteReader = new br.ByteReader();
+  byteReader.nextByte = () => {
+    const byte = buf[pos];
+    if (pos > buf.length) { throw new Error("nextByte called too many times."); }
+    pos++;
+    return byte;
+  };
+  byteReader.skipBytes = (numBytesToSkip) => {
+    pos += numBytesToSkip;
+  };
+  return byteReader;
+};
+
+const createTypeDescriptorTest = (typeDesc, expectedSuccessArray) => {
+  for (let i = 0 ; i < 16 ; ++i) {
+    const buf = [(16*typeDesc) + i, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255, 255];
+    // VarUInts (all 0x_E and sorted struct)
+    if (i === 14 || (typeDesc === types.IonTypes["struct"] && i === 1)) {
+      buf[1] = 142; // 8E
+    }
+    const singleUseByteReader = createSingleUseByteReader(buf);
+    tdReader = new tdr.TypeDescriptorReader(singleUseByteReader);
+    if (expectedSuccessArray[i] === true) {
+      let typeAndLength = undefined;
+
+      assert.doesNotThrow(() => { typeAndLength = tdReader.readTypeAndLength(0, "1_0"); });
+
+      // nop padding
+      if (typeDesc === types.IonTypes["null"] && i < 15) {
+        assert.strictEqual(typeAndLength.type, types.IonTypes["nop"]);
+      }
+      // bvm
+      else if(typeDesc === types.IonTypes["annotation"] && i === 0) {
+        assert.strictEqual(typeAndLength.type, types.IonTypes["bvm"]);
+      }
+      else {
+        assert.strictEqual(typeAndLength.type, typeDesc);
+      }
+
+      // bools have no length
+      if (typeDesc === types.IonTypes["bool"] && i === 1) {
+        assert.strictEqual(typeAndLength.length, 0);
+      }
+      // sorted structs have a length field which is set to 15 above
+      else if (typeDesc === types.IonTypes["struct"] && i === 1) {
+        assert.strictEqual(typeAndLength.length, 15);
+      }
+      // bvm has a length of 3
+      else if (typeDesc === types.IonTypes["annotation"] && i === 0) {
+        assert.strictEqual(typeAndLength.length, 3);
+      }
+      // VarUInts for each type are set to be a length of 15 above
+      else if (i === 14) {
+        assert.strictEqual(typeAndLength.length, 15);
+      }
+      // null value for each type
+      else if (i === 15) {
+        assert.strictEqual(typeAndLength.length, 0);
+        assert.strictEqual(typeAndLength.isNull, true);
+      }
+      else {
+        assert.strictEqual(typeAndLength.length, i);
+      }
+    }
+    else {
+      assert.throws(() => { tdReader.readTypeAndLength(); }, Error);
+    }
+  }
+};
+
+
+describe('TypeDescriptorReader', function() {
+  describe("constructor", function () {
+    it('should throw on an invalid byteReader', function() {
+      assert.throws(createReader, 
+                    Error );
+    });
+    it('should succeed when passed a byteReader', function() {
+      assert.doesNotThrow(function () { createReader(createSingleUseByteReader([0])) });
+    });
+  });
+  describe('readTypeAndLength', function() {
+    it('should parse T0', function() {
+      createTypeDescriptorTest(0, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T1', function() {
+      createTypeDescriptorTest(1, [
+        true,  // 0
+        true,  // 1
+        false, // 2
+        false, // 3
+        false, // 4
+        false, // 5
+        false, // 6
+        false, // 7
+        false, // 8
+        false, // 9
+        false, // A
+        false, // B
+        false, // C
+        false, // D
+        false, // E
+        true   // F
+      ]);
+    });
+    it('should parse T2', function() {
+      createTypeDescriptorTest(2, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T3', function() {
+      createTypeDescriptorTest(3, [
+        false, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T4', function() {
+      createTypeDescriptorTest(4, [
+        true, // 0
+        false, // 1
+        false, // 2
+        false, // 3
+        true, // 4
+        false, // 5
+        false, // 6
+        false, // 7
+        true, // 8
+        false, // 9
+        false, // A
+        false, // B
+        false, // C
+        false, // D
+        false, // E
+        true  // F
+      ]);
+    });
+    it('should parse T5', function() {
+      createTypeDescriptorTest(5, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T6', function() {
+      createTypeDescriptorTest(6, [
+        false, // 0
+        false, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T7', function() {
+      createTypeDescriptorTest(7, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T8', function() {
+      createTypeDescriptorTest(8, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T9', function() {
+      createTypeDescriptorTest(9, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T10', function() {
+      createTypeDescriptorTest(10, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T11', function() {
+      createTypeDescriptorTest(11, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T12', function() {
+      createTypeDescriptorTest(12, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T13', function() {
+      createTypeDescriptorTest(13, [
+        true, // 0
+        true, // 1
+        true, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        true  // F
+      ]);
+    });
+    it('should parse T14', function() {
+      createTypeDescriptorTest(14, [
+        true, // 0
+        false, // 1
+        false, // 2
+        true, // 3
+        true, // 4
+        true, // 5
+        true, // 6
+        true, // 7
+        true, // 8
+        true, // 9
+        true, // A
+        true, // B
+        true, // C
+        true, // D
+        true, // E
+        false  // F
+      ]);
+    });
+    it('should parse T15', function() {
+      createTypeDescriptorTest(15, [
+        false, // 0
+        false, // 1
+        false, // 2
+        false, // 3
+        false, // 4
+        false, // 5
+        false, // 6
+        false, // 7
+        false, // 8
+        false, // 9
+        false, // A
+        false, // B
+        false, // C
+        false, // D
+        false, // E
+        false  // F
+      ]);
+    });
+
+    // TODO: Expand this to test comprehensively
+    it('should parse VarUInts', function() {
+      const buf = [parseInt('0x0E', 16), parseInt('0x8E', 16)];
+      const singleUseByteReader = createSingleUseByteReader(buf);
+      tdReader = new tdr.TypeDescriptorReader(singleUseByteReader);
+      assert.doesNotThrow(() => { tdReader.readTypeAndLength(0, "1_0"); });
+    });
+  });
+});


### PR DESCRIPTION
This is the first import of the code currently running on the website. It has been cleaned up from the original source. Addresses part of #1.

Includes:
- __IonTypes__: *Enumerates the Ion types, plus internal types.*
- __ByteReader__: *Abstract class that provides a common interface for reading bytes.*
- __ByteBufferReader__: *Extends ByteReader to read bytes from an ArrayBuffer.*
- __TypeDescriptorReader__: *Reader for the type descriptor byte plus optional overflow length.*