### PR TITLE
ElementReference, IonElement and ScalarValueReader

### DIFF
--- a/src/core/ByteBufferReader.js
+++ b/src/core/ByteBufferReader.js
@@ -3,7 +3,7 @@
 const br = require('./ByteReader');
 
 /**
- * Reads bytes from a buffer.
+ * Reads bytes from a buffer.  
  * Extends ByteReader interface.
  */
 class ByteBufferReader extends br.ByteReader {
@@ -24,7 +24,7 @@ class ByteBufferReader extends br.ByteReader {
    * Loads a buffer into the ByteBufferReader.
    * 
    * @param {ArrayBuffer | Uint8Array} buffer
-   * @throws Error if the buffer does not exist.
+   * @throws `Error` if the buffer does not exist.
    * @returns {Number} the number of bytes in the buffer
    */
   loadBuffer (buffer) {
@@ -54,8 +54,8 @@ class ByteBufferReader extends br.ByteReader {
    * Moves the current position forward by 1 byte.
    * 
    * @returns {null | UInt8}
-   * - null if the current position is currently at the end of the buffer
-   * - the UInt8 at that position in the buffer
+   * - `null` if the current position is currently at the end of the buffer
+   * - `UInt8` byte at the position in the buffer
    */
   nextByte () {
     if (this.atEnd()) {
@@ -79,7 +79,7 @@ class ByteBufferReader extends br.ByteReader {
   }
 
   /**
-   * Skips forward the specified number of bytes.
+   * Skips forward the specified number of bytes.  
    * Note: This function does not check if the number of bytes to skip are valid.
    * 
    * @param {Number} numBytesToSkip The number of bytes for the reader to skip over.
@@ -89,7 +89,7 @@ class ByteBufferReader extends br.ByteReader {
   }
 
   /**
-   * Sets the position in the buffer to be the byte number passed in.
+   * Sets the position in the buffer to be the byte number passed in.  
    * Note: This function does not check if the position to set is valid.
    * 
    * @param {Number} positionToSet The new position to set the reader to.
@@ -100,11 +100,11 @@ class ByteBufferReader extends br.ByteReader {
 
   /**
    * Checks if the specified position is exactly at the end of the buffer.
-   * Throws an error if the position is beyond the end of the buffer.
    * @param {Number} position The position to check.
    * @returns {Boolean}
-   * - true if the position is at the end of the buffer
-   * - false if the position is still within the buffer
+   * - `true` if the position is at the end of the buffer
+   * - `false` if the position is still within the buffer
+   * - `null` if the position is past the end of the buffer
    */
   atEnd (position) {
     if (typeof position === "bigint") {

--- a/src/core/ElementReference.js
+++ b/src/core/ElementReference.js
@@ -39,10 +39,7 @@ function createElementReference(streamOffset, relativeOffset, depth, bytesRemain
  * @returns {Boolean} returns true if the passed in parameter is an ElementReference array, false otherwise.
  */
 function isElementReference(elementReference) {
-  if (Array.isArray(elementReference) && elementReference.length === 7) {
-    return true;
-  }
-  return false;
+  return (Array.isArray(elementReference) && elementReference.length === 7);
 }
 
 /**

--- a/src/core/ElementReference.js
+++ b/src/core/ElementReference.js
@@ -1,0 +1,90 @@
+'use strict';
+
+/**
+ * An ElementReference contains the structural information about an element.
+ * The structure of an ElementReference is as follows:  
+ * 0 - the offset in the stream for the current part of the stream  
+ * 1 - the relative offset beyond the start of the current part of the stream  
+ * 2 - the depth of the element  
+ * 3 - the number of bytes remaining at this depth  
+ * 4 - the absolute offset in the stream of the container  
+ * 5 - the type of the container  
+ * 6 - the absolute offset in the stream of the next element  
+ * Note: createElementReference does not require all of the parameters to be set.
+ * 
+ * @param {Number} streamOffset (uint)
+ * @param {Number} relativeOffset (uint)
+ * @param {Number} depth (uint)
+ * @param {Number} bytesRemainingAtDepth (uint)
+ * @param {Number} absoluteContainerOffset (uint)
+ * @param {IonType} containerType 
+ * @param {Number} absoluteNextOffset (uint)
+ * @returns {ElementReference} An Element Reference array initialized to the parameters passed in.
+ */
+function createElementReference(streamOffset, relativeOffset, depth, bytesRemainingAtDepth, absoluteContainerOffset,
+                                containerType, absoluteNextOffset) {
+  return [streamOffset,
+          relativeOffset,
+          depth,
+          bytesRemainingAtDepth,
+          absoluteContainerOffset,
+          containerType,
+          absoluteNextOffset ];
+}
+
+/**
+ * Checks if the parameter passed in is an ElementReference.
+ * 
+ * @param {ElementReference} elementReference 
+ * @returns {Boolean} returns true if the passed in parameter is an ElementReference array, false otherwise.
+ */
+function isElementReference(elementReference) {
+  if (Array.isArray(elementReference) && elementReference.length === 7) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Calculates and returns the next element from the passed in ElementReference.
+ * 
+ * @param {ElementReference} elementReference  
+ * @throws {Error} when absolute next offset is less than or equal to the stream offset + relative offset
+ * @returns {ElementReference} 
+ * - `ElementReference` to the next element
+ * - `undefined` or `null` if there is no next element
+ */
+function nextElementReference(elementReference) {
+  if (elementReference[6] === undefined || elementReference[6] === null) {
+    return elementReference[6];
+  }
+
+  if (elementReference[6] <= (elementReference[0]+elementReference[1])) {
+    const err = new Error(`ElementReference nextElementReference absolute next offset (${elementReference[6]}) <= stream offset + relative offset (${elementReference[0]} + ${elementReference[1]})`);
+    throw err;
+  }
+
+  // next ElementReference:
+  //      fileOffset,          relativeOffset (nextOffset - fileOffset),  depth,
+  return [elementReference[0], elementReference[6] - elementReference[0], elementReference[2],
+  //      bytesRemainingAtDepth (bytesRemainingAtDepth - (nextOffset-relativeOffset-fileOffset)),
+          elementReference[3] - (elementReference[6]-elementReference[1]-elementReference[0]),
+  //      containerOffset,     containerType,       nextOffset
+          elementReference[4], elementReference[5], undefined];
+}
+
+/**
+ * Calculates and returns the absolute offset of the passed in ElementReference.
+ * 
+ * @param {ElementReference} elementReference 
+ * @returns {Number}
+ */
+function absoluteOffset(elementReference) {
+  //     fileOffset + relativeOffset
+  return elementReference[0] + elementReference[1];
+}
+
+exports.createElementReference = createElementReference;
+exports.isElementReference = isElementReference;
+exports.nextElementReference = nextElementReference;
+exports.absoluteOffset = absoluteOffset;

--- a/src/core/IonElement.js
+++ b/src/core/IonElement.js
@@ -1,0 +1,924 @@
+'use strict';
+
+const { IonTypes } = require('./IonTypes');
+const ElementReference = require('./ElementReference');
+const { TypeDescriptorReader } = require('./TypeDescriptorReader');
+
+/**
+ * @example
+ *        7       4 3       0
+ *       +---------+---------+
+ * value |    T    |    L    |
+ *       +---------+---------+======+
+ *       :     length [VarUInt]     :
+ *       +==========================+
+ *       :      representation      :
+ *       +==========================+
+ * 
+ * @description
+ * Stores the "structure" (T/L and length) of an Ion element.  
+ * An Ion element includes any annotations that wrap it.  
+ * Does not store the representation (except for bools).
+ */
+class IonElement {
+  #type;              // 0-15 (T)
+  #isNull;            // true or false (L=15)
+  #annotations;       // Array of symbol ids (annot)
+  #fieldNameSymbolID; // 0 - ? (field name)
+  #isLocalSymbolTable = false;    // true or false
+  #isSharedSymbolTable = false;   // true or false
+
+  #majorVersion;
+  #minorVersion;
+
+  #reference;
+
+  // in bytes:
+  #length = 0; // number of bytes in the representation, including annotations wrapper (length) and varUInt length
+  #varUIntLength = 0; // number of bytes in the length VarUInt
+  #lengthWithoutAnnotations = 0; // number of bytes in the representation - annotations wrapper (length)
+  #varUIntLengthWithAnnotations = 0; // number of bytes in the length VarUInt (of T=14)
+  #annotationsLength = 0; // number of bytes in the annotations (annot_length of T=14)
+  #annotationsVarUIntLength = 0; // number of bytes in the annotations length VarUInt (annot of T=14)
+  #fieldNameVarUIntLength = 0; // number of bytes in the field mame length VarUInt
+
+  // info about other elements
+  #contains = null;
+
+  // booleans require special handling for retrieving the representation
+  #boolRepresentation = null;
+
+  // BVMs, struct elements with NOP, NOP
+  #isSystemElement = false;
+
+  // Structs with length 1
+  #isSorted = false;
+
+  #firstAnnotation = null;
+
+  /**
+   * Resets this element's properties to defaults.
+   */
+  #clear = () => {
+    this.#type = undefined;              // 0-15 (T)
+    this.#isNull = undefined;            // true or false (L=15)
+    this.#annotations = undefined;       // Array of symbol idsn(annot)
+    this.#fieldNameSymbolID = undefined; // 0 - ? (field name)
+    this.#isLocalSymbolTable = false;    // true or false
+    this.#isSharedSymbolTable = false;   // true or false
+
+    this.#majorVersion = undefined;
+    this.#minorVersion = undefined;
+  
+    this.#reference = undefined;
+
+    // in bytes:
+    this.#length = 0; // number of bytes in the representation, including annotations wrapper (length) and varUInt length
+    this.#varUIntLength = 0; // number of bytes in the length VarUInt
+    this.#lengthWithoutAnnotations = 0; // number of bytes in the representation - annotations wrapper (length)
+    this.#varUIntLengthWithAnnotations = 0; // number of bytes in the length VarUInt (of T=14)
+    this.#annotationsLength = 0; // number of bytes in the annotations (annot_length of T=14)
+    this.#annotationsVarUIntLength = 0; // number of bytes in the annotations length VarUInt (annot of T=14)
+    this.#fieldNameVarUIntLength = 0; // number of bytes in the field mame length VarUInt
+  
+    // info about other elements
+    this.#contains = null;
+  
+    // booleans require special handling for retrieving the representation
+    this.#boolRepresentation = null;
+  
+    // BVMs, struct elements with NOP, NOP
+    this.#isSystemElement = false;
+  
+    // Structs with length 1
+    this.#isSorted = false;
+  }
+
+  /**
+   * Sets this element's reference
+   * 
+   * @param {ElementReference} elementReference 
+   */
+  #initialize = (elementReference) => {
+    this.#reference = elementReference;
+
+    this.#annotations = [];
+  }
+
+  /**
+   * Requires an ElementReference
+   * 
+   * @param {ElementReference} elementReference
+   * @throws Error if elementReference is not an ElementReference
+   */
+  constructor (elementReference) {
+    if (!(ElementReference.isElementReference(elementReference))) {
+      const err = new Error(`IonElement constructor passed ${elementReference} instead of ElementReference.`);
+      throw err;
+    }
+
+    this.#initialize(elementReference);
+  }
+
+  /**
+   * Specifies what properties to stringify
+   * 
+   * @returns An object
+   */
+  toString () {
+    return `{ #reference: ${this.#reference},
+              #type: ${this.#type}, 
+              #isSystemElement: ${this.#isSystemElement},
+              #isNull: ${this.#isNull},
+              #isLocalSymbolTable: ${this.#isLocalSymbolTable},
+              #isSharedSymbolTable: ${this.#isSharedSymbolTable},
+              #annotations: ${this.#annotations},
+              #length: ${this.#length},
+              #varUIntLength: ${this.#varUIntLength},
+              #fieldNameVarUIntLength: ${this.#fieldNameVarUIntLength},
+              #fieldNameSymbolID: ${this.#fieldNameSymbolID},
+              #annotationsLength: ${this.#annotationsLength},
+              #annotationsVarUIntLength: ${this.#annotationsVarUIntLength},
+              #lengthWithoutAnnotations: ${this.#lengthWithoutAnnotations},
+              #contains: ${this.#contains},
+              bytePositionOfRepresentation: ${this.bytePositionOfRepresentation},
+              isContainer: ${this.isContainer} }`;
+  }
+
+  /**
+   * Repurposes (clears and reinitializes) this element to a new reference.
+   * 
+   * @param {ElementReference} elementReference 
+   * @throws Error if elementReference is not an ElementReference
+   */
+  repurpose (elementReference) {
+    if (!(ElementReference.isElementReference(elementReference))) {
+      const err = new Error(`IonElement repurpose passed ${elementReference} instead of ElementReference.`);
+      throw err;
+    }
+
+    this.#clear();
+    this.#initialize(elementReference);
+  }
+
+  /**
+   * The reference for this element.
+   * 
+   * @returns An ElementReference
+   */
+  reference() {
+    return this.#reference;
+  }
+
+  /**
+   * Reads the T/L and length of an element. Also reads bvms.
+   * @example
+   *        7       4 3       0
+   *       +---------+---------+
+   * value |    T    |    L    |
+   *       +---------+---------+======+
+   *       :     length [VarUInt]     :
+   *       +==========================+
+   *       :      representation      :
+   *       +==========================+
+   * @example
+   *                        7    0 7     0 7     0 7    0
+   *                       +------+-------+-------+------+
+   * binary version marker | 0xE0 | major | minor | 0xEA |
+   *                       +------+-------+-------+------+
+   * @param {TypeDescriptorReader} typeReader 
+   * @param {String} context Can be either "1_0" or "bvm"
+   * @throws 
+   * @returns 
+   */
+  readTypeDescriptor (typeReader, context) {
+    // 1- relativeOffset
+    let position = this.#reference[1];
+  
+    // read field name, if in a struct
+    let fieldNameInfo = undefined;
+        // 4- containerOffset
+    if (this.#reference[4] !== null && 
+        // 5- containerType
+        this.#reference[5] === IonTypes["struct"]) {
+      fieldNameInfo = typeReader.readFieldName(position);
+
+      // not enough bytes available, propagate null
+      if (fieldNameInfo === null) {
+        return null;
+      }
+
+      position += fieldNameInfo.numBytesRead;
+    }
+    let currentType = typeReader.readTypeAndLength(position, context);
+
+    // not enough bytes available, reset reader position, propagate null
+    if (currentType === null) {
+      // 1- relativeOffset
+      typeReader.setPosition(this.#reference[1]);
+      return null;
+    }
+
+    // set before we check for annotations, ensures the length includes annotation wrapper
+    this.#length = currentType.length || 0;
+  
+    let annotationInfo = undefined;
+    // annotations wrap an element. Combine the annotation into the next element.
+    if (currentType.type === IonTypes["annotation"]) {
+      annotationInfo = currentType;
+  
+      if (!Number.isInteger(annotationInfo.annotationsVarUIntLength) ||
+          !Number.isInteger(annotationInfo.annotationsLength)) {
+            const err = new Error("Annotation missing 'annot_length' field data.");
+            throw err;
+      }
+  
+      if (annotationInfo.annotationsLength === 0) {
+        const err = new Error("'annot_length' field must be greater than zero.");
+        throw err;
+      }
+
+      let annotationsLengthRemaining = annotationInfo.annotationsLength;
+
+      // current position + 1 for the T/L byte + varUInt length (if present) +
+      // annotations varUInt length
+      let annotationPosition = position + 1 + (annotationInfo.varUIntLength || 0) +
+                               annotationInfo.annotationsVarUIntLength;
+      let annotation;
+      do {
+        annotation = typeReader.readFieldName(annotationPosition);
+        // not enough bytes available, reset reader position, propagate null
+        if (annotation === null) {
+          // 1- relativeOffset
+          typeReader.setPosition(this.#reference[1]);
+          return null;
+        }
+
+        this.#annotations.push(annotation);
+        annotationPosition += annotation.numBytesRead;
+        annotationsLengthRemaining -= annotation.numBytesRead;
+      } while (annotationsLengthRemaining > 0);
+
+      const firstAnnotation = this.#annotations[0];
+  
+      // current position + 1 for the T/L byte + varUInt length (if present) +
+      // annotations varUInt length + length of annotations
+      const valuePosition = position + 1 + (annotationInfo.varUIntLength || 0) +
+                            annotationInfo.annotationsVarUIntLength + annotationInfo.annotationsLength;
+      currentType = typeReader.readTypeAndLength(valuePosition, context);
+
+      // not enough bytes available, reset reader position, propagate null
+      if (currentType === null) {
+        // 1- relativeOffset
+        typeReader.setPosition(this.#reference[1]);
+        return null;
+      }
+  
+      if (currentType.type === IonTypes["annotation"]) {
+        const err = new Error("Annotations cannot wrap annotations.");
+        throw err;
+      }
+      else if (currentType.type === IonTypes["nop"]) {
+        const err = new Error("Annotations cannot wrap nop.");
+        throw err;
+      }
+  
+      // local symbol table (0x83) or shared symbol table (0x89)
+      if (firstAnnotation.magnitude === 3 || firstAnnotation.magnitude === 9) {
+        // depth > 0, warn
+        // 2- depth
+        if (this.#reference[2] > 0) {
+          const err = new Error("Symbol table annotation is not at depth 0.");
+          throw err;
+        }
+
+        // element is not struct, warn
+        if (currentType.type !== IonTypes["struct"]) {
+          const err = new Error("Symbol table annotation is not wrapping struct.");
+          throw err;
+        }
+
+        if (firstAnnotation.magnitude === 3) {
+          this.#isLocalSymbolTable = true;
+        } else {
+          this.#isSharedSymbolTable = true;
+        }
+
+        this.#firstAnnotation = firstAnnotation;
+        this.#isSystemElement = true;
+      }
+
+      currentType.annotationsVarUIntLength = annotationInfo.annotationsVarUIntLength;
+      currentType.annotationsLength = annotationInfo.annotationsLength;
+      currentType.varUIntLengthWithAnnotations = annotationInfo.varUIntLength;
+    }
+  
+    // BVMs are system elements and only valid at depth 0
+    if (currentType.type === IonTypes["bvm"]) {
+      // 2- depth
+      if (this.#reference[2] !== 0) {
+        const err = new Error(`BVM encountered at depth ${this.#reference[2]}`);
+        throw err;
+      }
+  
+      this.#isSystemElement = true;
+      this.#majorVersion = currentType.majorVersion;
+      this.#minorVersion = currentType.minorVersion;
+    }
+
+    // nop values are system elements
+    if (currentType.type === IonTypes["nop"]) {
+      this.#isSystemElement = true;
+    }
+
+    // sorted struct
+    if (currentType.type === IonTypes["struct"] && currentType.isSortedStruct) {
+      this.#isSorted = true;
+
+      // must have a length
+      if ((currentType.length - currentType.varUIntLength) === 0) {
+        const err = new Error(`Sorted struct with no length.`);
+        throw err;
+      }
+    }
+
+    // always set lengthWithoutAnnotations even if there are no annotations
+    currentType.lengthWithoutAnnotations = currentType.length;
+
+    this.#type = currentType.type;
+    this.#isNull = currentType.isNull;
+    this.#varUIntLength = currentType.varUIntLength || 0;
+    this.#annotationsLength = currentType.annotationsLength || 0;
+    this.#annotationsVarUIntLength = currentType.annotationsVarUIntLength || 0;
+    this.#lengthWithoutAnnotations = currentType.lengthWithoutAnnotations || 0;
+    this.#varUIntLengthWithAnnotations = currentType.varUIntLengthWithAnnotations || 0;
+
+    if (fieldNameInfo) {
+      this.#fieldNameSymbolID = fieldNameInfo.magnitude;
+      this.#fieldNameVarUIntLength = fieldNameInfo.numBytesRead;
+    }
+
+    if (this.#type === IonTypes["bool"]) {
+      this.#boolRepresentation = currentType.bool;
+    }
+
+    // 1 is for the type descriptor byte
+    let totalLength;
+    if (typeof this.#length === 'bigint' || typeof this.#fieldNameVarUIntLength === 'bigint') {
+      totalLength = 1n + BigInt(this.#length) + BigInt(this.#fieldNameVarUIntLength);
+    } else {
+      totalLength = 1 + this.#length + this.#fieldNameVarUIntLength;
+    }
+
+    // if this is a container, create the child element
+    if (IonTypes.isContainer(this.#type) && this.#lengthWithoutAnnotations !== 0 && this.#isNull === false) {
+
+      if (typeof totalLength === 'bigint') {
+        this.#contains = ElementReference.createElementReference(
+          // file offset
+          this.#reference[0],
+          // offset
+          this.bytePositionOfRepresentation,
+          // depth
+          this.#reference[2]+1,
+          // bytes remaining at depth
+          // 1- relativeOffset
+          (totalLength - BigInt(this.bytePositionOfRepresentation - this.#reference[1])),
+          // container element (this element)
+          // 1- relativeOffset, 0- fileOffset
+          this.#reference[1] + this.#reference[0],
+          // container element type (this element)
+          this.#type,
+          // next offset
+          undefined
+        );
+      } else {
+        this.#contains = ElementReference.createElementReference(
+          // file offset
+          this.#reference[0],
+          // offset
+          this.bytePositionOfRepresentation,
+          // depth
+          this.#reference[2]+1,
+          // bytes remaining at depth
+          // 1- relativeOffset
+          (totalLength - (this.bytePositionOfRepresentation - this.#reference[1])),
+          // container element (this element)
+          // 1- relativeOffset, 0- fileOffset
+          this.#reference[1] + this.#reference[0],
+          // container element type (this element)
+          this.#type,
+          // next offset
+          undefined
+        );
+      }
+    }
+
+    // if there are bytesRemainingAtDepth, create the next element
+    let newBytesRemaining;
+    // 3- bytesRemainingAtDepth
+    if (typeof totalLength === 'bigint' || typeof this.#reference[3] === 'bigint') {
+      newBytesRemaining = BigInt(this.#reference[3]) - BigInt(totalLength);
+      if (newBytesRemaining > 0n) {
+        // 6- nextOffset 1- relativeOffset 0- fileOffset
+        this.#reference[6] = BigInt(this.#reference[1]) + BigInt(totalLength) + BigInt(this.#reference[0]);
+      }
+      else if (newBytesRemaining < 0n) {
+        typeReader.setPosition(this.#reference[1]);
+        return null;
+      }
+      else {      
+        // intentionally do nothing if newBytesRemaining === 0
+      }
+    } else {
+      // 3- bytesRemainingAtDepth
+      newBytesRemaining = this.#reference[3] - totalLength;
+      if (newBytesRemaining > 0) {
+        // 6- nextOffset 1- relativeOffset 0- fileOffset
+        this.#reference[6] = this.#reference[1] + totalLength + this.#reference[0];
+      }
+      else if (newBytesRemaining < 0) {
+        typeReader.setPosition(this.#reference[1]);
+        return null;
+      }
+      else {      
+        // intentionally do nothing if newBytesRemaining === 0
+      }
+    }
+  }
+
+  /**
+   * Calculates the relative offset in the stream for this element's value representation.
+   * 
+   * @returns
+   * - `null` for byte positions of bvm, nop, 0 length values, and null values
+   * - `Number` the number of relative bytes to this element's representation
+   */
+  get bytePositionOfRepresentation() {
+    if (this.#type === IonTypes["bvm"] || this.#type === IonTypes["nop"]) {
+      return null;
+    }
+
+    if (this.#lengthWithoutAnnotations === 0) {
+      return null;
+    }
+
+    if (this.#isNull) {
+      return null;
+    }
+
+    // 1- relativeOffset
+    return this.#reference[1] + 
+           this.#fieldNameVarUIntLength +
+           // if there are annotations on this element
+           ( (this.#annotationsLength > 0) ?
+           // 1 for T/L of annotations wrapper
+             (1 + this.#varUIntLengthWithAnnotations + this.#annotationsVarUIntLength + this.#annotationsLength) : 
+             (0)
+           ) + 
+           // 1 for T/L of value
+           1 + this.#varUIntLength;
+  }
+
+  /**
+   * Calculates the relative offset in the stream for this element's annotations
+   * 
+   * @returns 
+   * - `null` for elements without annotations
+   * - `Number` the number of relative bytes to this element's annotations
+   */
+  get bytePositionOfAnnotations() {
+    if (!(this.#annotationsLength > 0)) {
+      return null;
+    }
+
+    // 1- relativeOffset
+    return this.#reference[1] + 
+           // 1 for T/L of annotations wrapper
+           (this.#fieldNameVarUIntLength + 1 + this.#varUIntLengthWithAnnotations + this.#annotationsVarUIntLength);
+  }
+
+  /**
+   * @returns
+   * - `true` if the element is a container type
+   * - `false` if the element is not a container type
+   */
+  get isContainer() {
+    return IonTypes.isContainer(this.#type);
+    // TODO: is the below also acceptable?
+    // return this.#contains !== null;
+  }
+
+  /** 
+   * @returns
+   * - `true` if the element is a scalar type
+   * - `false` if the element is not a scalar type
+   */
+  get isScalar() {
+    return IonTypes.isScalar(this.#type);
+  }
+
+  /**
+   * @returns
+   * - `true` if the element is a null value
+   * - `false` if the element is not a null value
+   */
+  get isNull() {
+    return this.#isNull;
+  }
+
+  /**
+   * @returns
+   * - `ElementReference` for the first element contained in this container
+   * - `null` if there are no elements in the container or this is not a container
+   */
+  get containsElement() {
+    return this.#contains;
+  }
+
+  /**
+   * @returns
+   * - `ElementReference` for the next element at this depth in the same container
+   * - `null` if there are no elements left at this depth in the same container
+   */
+  get nextElementReference() {
+    return ElementReference.nextElementReference(this.#reference);
+  }
+
+  /**
+   * @returns {Number} the absolute bytes of the element position in the stream
+   */
+  get absoluteOffset() {
+    return ElementReference.absoluteOffset(this.#reference);
+  }
+
+  /**
+   * @returns {Number} the relative bytes of the element position in the stream
+   */
+  get relativeOffset() {
+    // 1- relativeOffset
+    return this.#reference[1];
+  }
+
+  /**
+   * @returns {Number} the depth of the element
+   */
+  get depth() {
+    // 2- depth
+    return this.#reference[2];
+  }
+
+  /**
+   * @returns {Number} the absolute offset of the container of this element
+   */
+  get container() {
+    // 4- containerOffset
+    return this.#reference[4];
+  }
+
+  /**
+   * @returns {IonType} the type of container this element is contained inside
+   */
+  get containerType() {
+    // 5- containerType
+    return this.#reference[5];
+  }
+
+  /**
+   * This length includes any field names and the T/L byte
+   * 
+   * @returns
+   * - `bigint` the number of total bytes in this element if the element length is larger than a Number
+   * - `Number` the number of total bytes in this element 
+   */
+  get totalLength() {
+    let totalLength;
+    if (typeof this.#length === 'bigint') {
+      totalLength = BigInt(this.#fieldNameVarUIntLength) + 1n + this.#length;
+    } else {
+      totalLength = this.#fieldNameVarUIntLength + 1 + this.#length;
+    }
+    return totalLength;
+  }
+
+  /**
+   * If the element has annotations, this length will be the length from the annotation wrapper 
+   * (including the annotation wrapper varUInt length)
+   * 
+   * @returns
+   * - `bigint` the number of bytes in this element if the element length is larger than a Number
+   * - `Number` the number of bytes in this element 
+   */
+  get length() {
+    return this.#length;
+  }
+
+  /**
+   * The safe property to use when looking for the length of a scalar value
+   * 
+   * @returns {Number} the number of bytes not including annotations for this element
+   */
+  get lengthWithoutAnnotations() {
+    return this.#lengthWithoutAnnotations;
+  }
+
+  /**
+   * @returns 
+   * - `IonType` the type of the element
+   * - `undefined` if the element is uninitialized
+   */
+  get type() {
+    return this.#type;
+  }
+
+  /**
+   * @returns
+   * - `Number` the major version of the BVM
+   * - `undefined` if the element is not a BVM
+   */
+  get majorVersion() {
+    return this.#majorVersion;
+  }
+
+  /**
+   * @returns
+   * - `Number` the minor version of the BVM
+   * - `undefined` if the element is not a BVM
+   */
+  get minorVersion() {
+    return this.#minorVersion;
+  }
+
+  /**
+   * @returns
+   * - `Number` the field name symbol ID if the element is in a struct
+   * - `undefined` if the element is not in a struct
+   */
+  get fieldNameSymbolID() {
+    return this.#fieldNameSymbolID;
+  }
+
+  /**
+   * @returns {Array} array of symbol ids (annot)
+   */
+  get annotations() {
+    return this.#annotations;
+  }
+
+  /**
+   * @returns {Number} the number of bytes in the annotations (annot_length of T=14)
+   */
+  get annotationsLength() {
+    return this.#annotationsLength;
+  }
+
+  /**
+   * @returns {Number} the number of bytes in the annotations length VarUInt (annot of T=14)
+   */
+  get annotationsVarUIntLength() {
+    return this.#annotationsVarUIntLength;
+  }
+
+
+  // TODO: this variable name is confusing, it is actually the length of the annotations varUInt.
+  /**
+   * @returns {Number} the number of bytes in the length VarUInt (of T=14) if there are annotations
+   */
+  get varUIntLengthWithAnnotations() {
+    return this.#varUIntLengthWithAnnotations;
+  }
+
+  /**
+   * @returns {Number} the number of bytes in the length VarUInt
+   */
+  get varUIntLength() {
+    return this.#varUIntLength;
+  }
+
+  /**
+   * @returns
+   * - `true` if the element is a Boolean and is true
+   * - `false` if the element is a Boolean and is false
+   * - `undefined` if the element is a Boolean and is null.boolean
+   * - `null` if the element is a not a Boolean
+   */
+  get boolRepresentation() {
+    return this.#boolRepresentation;
+  }
+
+  /**
+  * @returns
+  * - `true` if the element is a system element
+  * - `false` if the element is not a system element
+  */
+  get isSystemElement() {
+    return this.#isSystemElement;
+  }
+
+  /**
+  * @returns
+  * - `true` if the element is a sorted struct
+  * - `false` if the element is not a sorted struct
+  */
+  get isSorted() {
+    return this.#isSorted;
+  }
+
+  /**
+  * @returns
+  * - `true` if the element is a local symbol table
+  * - `false` if the element is not a local symbol table
+  */
+  get isLocalSymbolTable() {
+    return this.#isLocalSymbolTable;
+  }
+
+  /**
+  * @returns
+  * - `true` if the element is a shared symbol table
+  * - `false` if the element is not a shared symbol table
+  */
+  get isSharedSymbolTable() {
+    return this.#isSharedSymbolTable;
+  }
+
+  /**
+   * @returns {Number} the symbol ID of the first annotation wrapping this element
+   */
+  get firstAnnotation() {
+    return this.#firstAnnotation;
+  }
+
+  /**
+   * @returns {Number} the number of bytes remaining (including this element) at the current depth
+   */
+  get bytesRemainingAtDepth() {
+    // 3- bytesRemainingAtDepth
+    return this.#reference[3];
+  }
+
+  /**
+   * @returns {Number} the number of bytes in the field mame length VarUInt
+   */
+  get fieldNameVarUIntLength() {
+    return this.#fieldNameVarUIntLength;
+  }
+
+  /**
+   * @example
+   *   {
+   *  depth: 0,
+   *  fieldName: {
+   *    nibbles: {
+   *      symbolStart: 0,
+   *      symbolEnd: 1
+   *    }
+   *    symbolMagnitude: 0
+   *  },
+   *  annotation: {
+   *    nibbles: {
+   *      type: 0,
+   *      wrapperLengthStart: 1,
+   *      wrapperLengthEnd: 1,
+   *      annotationsLengthStart: 2,
+   *      annotationsLengthEnd: 2
+   *    }
+   *    lengthValue: 3,
+   *    annotations: [
+   *      {
+   *        nibbles: {
+   *          symbolStart: 4,
+   *          symbolEnd: 5
+   *        },
+   *        symbolMagnitude: 0
+   *      }
+   *    ]
+   *  },
+   *  element: {
+   *    nibbles: {
+   *      type: 0,
+   *      lengthStart: 1,
+   *      lengthEnd: 1
+   *    },
+   *    typeValue: 0,
+   *    lengthValue: 0
+   *    // type specific info added here
+   *   }
+   * }
+   * 
+   * @throws
+   * @returns
+   */
+  get nibblePositionStruct() {
+    const struct = {};
+    let position = 0;
+
+    // 1- relativeOffset 2- depth
+    struct.offset = this.#reference[1];
+    struct.depth = this.#reference[2];
+    if (typeof this.totalLength === 'bigint') {
+      struct.totalNibbles = this.totalLength * 2n;
+    } else {
+      struct.totalNibbles = this.totalLength * 2;
+    }
+
+    if (this.#fieldNameSymbolID === undefined) {
+      struct.fieldName = null;
+    } else {
+      const fieldNameStruct = {};
+
+      fieldNameStruct.symbolMagnitude = this.fieldNameSymbolID;
+      fieldNameStruct.nibbles = {};
+      // this should always be 0 and is enforced elsewhere
+      fieldNameStruct.nibbles.symbolStart = position;
+      fieldNameStruct.nibbles.symbolEnd = position + (this.fieldNameVarUIntLength * 2) - 1;
+
+      struct.fieldName = fieldNameStruct;
+
+      position = fieldNameStruct.nibbles.symbolEnd + 1;
+    }
+
+    if (this.annotationsLength === 0) {
+      struct.annotation = {};
+    } else {
+      const annotationStruct = {};
+      const nibbles = {};
+
+      // Annotation:
+      // 1        - nibbles.type                              - nibble:T (type)
+      // 2        - nibbles.wrapperLengthStart                - nibble:L (length)
+      // [3,4...] - nibbles.wrapperLengthEnd                  - nibble:VarUInt Length of wrapper
+      // 3,4...   - nibbles.annotationsLengthStart            - nibble:VarUInt Length of annotations
+      //          - nibbles.annotationswrapperLengthEnd       -
+      // 5,6...   - nibbles.annotation[i].nibbles.symbolStart - nibble:VarUInt Annotation (symbol ID)
+      //          - nibbles.annotation[i].nibbles.symbolEnd   -
+      // 7,8... - value 
+
+      nibbles.type = position;
+      position += 1;
+
+      nibbles.wrapperLengthStart = position;
+      nibbles.wrapperLengthEnd = position + (this.#varUIntLengthWithAnnotations * 2);
+
+      position = nibbles.wrapperLengthEnd + 1;
+
+      nibbles.annotationsLengthStart = position;
+      nibbles.annotationsLengthEnd = position + (this.#annotationsVarUIntLength * 2) - 1;
+      position = nibbles.annotationsLengthEnd + 1;
+      annotationStruct.wrapperLengthValue = this.#length;
+      annotationStruct.lengthValue = this.annotationsLength; // byte length of annotations
+
+      const annotationList = [];
+
+      for (let i = 0; i < this.annotations.length; ++i) {
+        const annotation = {};
+
+        annotation.nibbles = {};
+
+        annotation.nibbles.symbolStart = position;
+        annotation.nibbles.symbolEnd = position + (this.annotations[i].numBytesRead * 2) - 1;
+        position = annotation.nibbles.symbolEnd + 1;
+
+        annotation.symbolMagnitude = this.annotations[i].magnitude;
+
+        annotationList.push(annotation);
+      }
+
+      annotationStruct.nibbles = nibbles;
+      annotationStruct.annotations = annotationList;
+      struct.annotation = annotationStruct;
+    }
+
+    const element = {};
+    const nibbles = {};
+
+    nibbles.type = position;
+    position += 1;
+    nibbles.lengthStart = position;
+    nibbles.lengthEnd = position + (this.varUIntLength * 2);
+
+    position = nibbles.lengthEnd +1;
+    if (position === struct.totalNibbles) {
+      // no representation nibbles
+    } else if (position < struct.totalNibbles) {
+      nibbles.representationStart = position;
+      nibbles.representationEnd = struct.totalNibbles - 1;
+    } else {
+      const err = new Error(`nibblePositionStruct has invalid position ${postion} out of ${struct.totalNibbles} for representationLength` );
+      throw err;
+    }
+
+    element.typeValue = this.type;
+    element.typeName = IonTypes.nameFromType(this.type);
+    element.lengthValue = this.lengthWithoutAnnotations - this.varUIntLength;
+    element.totalLength = this.totalLength;
+
+    element.nibbles = nibbles;
+    struct.element = element;
+
+    return struct;
+  }
+
+}
+
+exports.IonElement = IonElement;

--- a/src/core/IonElement.js
+++ b/src/core/IonElement.js
@@ -890,19 +890,19 @@ class IonElement {
     }
 
     const element = {};
-    const nibbles = {};
+    const element_nibbles = {};
 
-    nibbles.type = position;
+    element_nibbles.type = position;
     position += 1;
-    nibbles.lengthStart = position;
-    nibbles.lengthEnd = position + (this.varUIntLength * 2);
+    element_nibbles.lengthStart = position;
+    element_nibbles.lengthEnd = position + (this.varUIntLength * 2);
 
-    position = nibbles.lengthEnd +1;
+    position = element_nibbles.lengthEnd +1;
     if (position === struct.totalNibbles) {
       // no representation nibbles
     } else if (position < struct.totalNibbles) {
-      nibbles.representationStart = position;
-      nibbles.representationEnd = struct.totalNibbles - 1;
+      element_nibbles.representationStart = position;
+      element_nibbles.representationEnd = struct.totalNibbles - 1;
     } else {
       const err = new Error(`nibblePositionStruct has invalid position ${postion} out of ${struct.totalNibbles} for representationLength` );
       throw err;
@@ -913,7 +913,7 @@ class IonElement {
     element.lengthValue = this.lengthWithoutAnnotations - this.varUIntLength;
     element.totalLength = this.totalLength;
 
-    element.nibbles = nibbles;
+    element.nibbles = element_nibbles;
     struct.element = element;
 
     return struct;

--- a/src/core/IonElement.js
+++ b/src/core/IonElement.js
@@ -285,7 +285,7 @@ class IonElement {
   
       // local symbol table (0x83) or shared symbol table (0x89)
       if (firstAnnotation.magnitude === 3 || firstAnnotation.magnitude === 9) {
-        // depth > 0, warn
+        // depth is greater than 0, warn
         // 2- depth
         if (this.#reference[2] > 0) {
           const err = new Error("Symbol table annotation is not at depth 0.");
@@ -488,7 +488,7 @@ class IonElement {
    * - `Number` the number of relative bytes to this element's annotations
    */
   get bytePositionOfAnnotations() {
-    if (!(this.#annotationsLength > 0)) {
+    if (this.#annotationsLength <= 0) {
       return null;
     }
 
@@ -842,7 +842,7 @@ class IonElement {
       struct.annotation = {};
     } else {
       const annotationStruct = {};
-      const nibbles = {};
+      const annot_nibbles = {};
 
       // Annotation:
       // 1        - nibbles.type                              - nibble:T (type)
@@ -854,37 +854,37 @@ class IonElement {
       //          - nibbles.annotation[i].nibbles.symbolEnd   -
       // 7,8... - value 
 
-      nibbles.type = position;
+      annot_nibbles.type = position;
       position += 1;
 
-      nibbles.wrapperLengthStart = position;
-      nibbles.wrapperLengthEnd = position + (this.#varUIntLengthWithAnnotations * 2);
+      annot_nibbles.wrapperLengthStart = position;
+      annot_nibbles.wrapperLengthEnd = position + (this.#varUIntLengthWithAnnotations * 2);
 
-      position = nibbles.wrapperLengthEnd + 1;
+      position = annot_nibbles.wrapperLengthEnd + 1;
 
-      nibbles.annotationsLengthStart = position;
-      nibbles.annotationsLengthEnd = position + (this.#annotationsVarUIntLength * 2) - 1;
-      position = nibbles.annotationsLengthEnd + 1;
+      annot_nibbles.annotationsLengthStart = position;
+      annot_nibbles.annotationsLengthEnd = position + (this.#annotationsVarUIntLength * 2) - 1;
+      position = annot_nibbles.annotationsLengthEnd + 1;
       annotationStruct.wrapperLengthValue = this.#length;
       annotationStruct.lengthValue = this.annotationsLength; // byte length of annotations
 
       const annotationList = [];
 
-      for (let i = 0; i < this.annotations.length; ++i) {
+      for (let annot_value of this.annotations) {
         const annotation = {};
 
         annotation.nibbles = {};
 
         annotation.nibbles.symbolStart = position;
-        annotation.nibbles.symbolEnd = position + (this.annotations[i].numBytesRead * 2) - 1;
+        annotation.nibbles.symbolEnd = position + (annot_value.numBytesRead * 2) - 1;
         position = annotation.nibbles.symbolEnd + 1;
 
-        annotation.symbolMagnitude = this.annotations[i].magnitude;
+        annotation.symbolMagnitude = annot_value.magnitude;
 
         annotationList.push(annotation);
       }
 
-      annotationStruct.nibbles = nibbles;
+      annotationStruct.nibbles = annot_nibbles;
       annotationStruct.annotations = annotationList;
       struct.annotation = annotationStruct;
     }

--- a/src/core/ScalarValueReader.js
+++ b/src/core/ScalarValueReader.js
@@ -568,7 +568,7 @@ class ScalarValueReader {
   read(type, position, length) {
     if (this.#readScalarFuncs[type] === undefined) {
       // TODO: pass the error to the caller
-      const err = new Error(`ScalarValueReader read() called with non-existant type ${type}.`);
+      const err = new Error(`ScalarValueReader read() called with non-existent type ${type}.`);
       throw err;
     }
 

--- a/src/core/ScalarValueReader.js
+++ b/src/core/ScalarValueReader.js
@@ -1,0 +1,617 @@
+'use strict';
+
+const br = require('./ByteReader');
+const { IonElement } = require('./IonElement');
+const { IonTypes } = require('./IonTypes');
+
+/**
+ * Reads Ion scalar values (beyond the Type Descriptor) from a ByteReader.  
+ * The Ion scalar values are Bool, Int, Float, Decimal, Timestamp, Symbol, String, Clob, and Blob.  
+ * Bool does not require reading beyond the Type Descriptor.
+ */
+class ScalarValueReader {
+  
+  /**
+   * Used for reading UTF8.  
+   * TextDecoder support is non-existent in IE/Edge.
+   */
+  #textDecoder;
+
+  /**
+   * Used for reading bytes.
+   */
+  #byteReader;
+
+  /**
+   * Reads the representation (magnitude) portion of a positive Int value
+   * 
+   * @example
+   *           7       4 3       0
+   *           +---------+---------+
+   * Int value |0x2 / 0x3|    L    |
+   *           +---------+---------+======+
+   *           :     length [VarUInt]     :
+   *           +==========================+
+   *           :     magnitude [UInt]     :
+   *           +==========================+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br 
+   * @returns {Number} the magnitude of the positive Int
+   */
+  #readInt = function (position, length, br) {
+    br.setPosition(position);
+
+    const value = br.readUInt(length).magnitude;
+
+    if (((length > 3) && value === 0n) || value === 0) {
+      // TODO: Warn that a zero is stored with extra padding
+    }
+
+    return value;
+  };
+
+  /**
+   * Reads the representation (magnitude) portion of a negative Int value
+   * 
+   * @example
+   *           7       4 3       0
+   *           +---------+---------+
+   * Int value |0x2 / 0x3|    L    |
+   *           +---------+---------+======+
+   *           :     length [VarUInt]     :
+   *           +==========================+
+   *           :     magnitude [UInt]     :
+   *           +==========================+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br 
+   * @returns {Number} the magnitude of the negative Int
+   */
+  #readNegativeInt = function (position, length, br) {
+    br.setPosition(position);
+
+    const value = br.readUInt(length).magnitude;
+    
+    if (((length > 3) && value === 0n) || value === 0) {
+      // TODO: pass the error to the caller
+      const err = new Error(`readNegativeInt() zero not a valid negative int value.`);
+      throw err;
+    }
+
+    return -value;
+  };
+
+  /**
+   * Reads the IEEE-754 representation of a Float value.
+   * Supports 32- and 64-bit floats.
+   * 
+   * @example
+   *               7       4 3       0
+   *             +---------+---------+
+   * Float value |   0x4   |    L    |
+   *             +---------+---------+-----------+
+   *             |   representation [IEEE-754]   |
+   *             +-------------------------------+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br 
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `Object` with exponent and coefficient properties
+   */
+  #readFloat = function (position, length, br) {
+    if (length !== 4 && length !== 8) {
+      // TODO: pass the error to the caller
+      const err = new Error(`ScalarValueReader illegal float length ${length}.`);
+      throw err;
+    }
+
+    const buffer = new Uint8Array(length);
+    br.setPosition(position);
+    for (let i = 0; i < length; ++i) {
+      buffer[i] = br.nextByte();
+
+      // not enough bytes available, reset reader position (i), propagate null
+      if (buffer[i] === null) {
+        br.skipBytes(-1 * i);
+        return null;
+      }
+    }
+
+    let tempBuf;
+    switch (length) {
+        case 4:
+            tempBuf = new DataView(buffer.buffer);
+            return tempBuf.getFloat32(0, false);
+        case 8:
+            tempBuf = new DataView(buffer.buffer);
+            return tempBuf.getFloat64(0, false);
+        default:
+            // do nothing. Handled at beginning of function.
+    }
+  };
+
+  /**
+   * Reads the representation (exponent and coefficient) of a Decimal value.
+   * 
+   * @example
+   *                7       4 3       0
+   *               +---------+---------+
+   * Decimal value |   0x5   |    L    |
+   *               +---------+---------+======+
+   *               :     length [VarUInt]     :
+   *               +--------------------------+
+   *               |    exponent [VarInt]     |
+   *               +--------------------------+
+   *               |    coefficient [Int]     |
+   *               +--------------------------+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `Object` with exponent and coefficient properties
+   */
+  #readDecimal = function (position, length, br) {
+    br.setPosition(position);
+
+    const exponent = br.readVarInt();
+
+    // not enough bytes available, propagate null
+    if (exponent === null) {
+      return null;
+    }
+
+    const coefficientLength = length - exponent.numBytesRead;
+    let coefficient;
+
+    if (coefficientLength < 0) {
+      // TODO: pass the error to the caller
+      const err = new Error(`ScalarValueReader illegal coefficient length.`);
+      throw err;
+    }
+
+    if (coefficientLength === 0) {
+      // coefficient is positive 0
+      coefficient = { magnitude: 0, numBytesRead: 0, isNegative: false };
+    } else {
+      coefficient = br.readInt(coefficientLength);
+
+      // not enough bytes available, reset reader position (coefficient), propagate null
+      if (coefficient === null) {
+        br.skipBytes(-1 * exponent.numBytesRead);
+        return null;
+      }
+
+      if (coefficient.isNegative === false && (coefficient.magnitude === 0 || coefficient.magnitude === 0n)) {
+        // TODO: if coefficient is positive 0, warn (coefficient should have length 0)
+      }
+    }
+
+    return { exponent: exponent, coefficient: coefficient };
+  };
+
+  /**
+   * Reads the representation (offset, year, month, day, hour, minute, second, fraction_exponent, fraction_coefficient)
+   * portion of a Timestamp value.
+   * 
+   * @example
+   *                  7       4 3       0
+   *                 +---------+---------+
+   * Timestamp value |   0x6   |    L    |
+   *                 +---------+---------+========+
+   *                 :      length [VarUInt]      :
+   *                 +----------------------------+
+   *                 |      offset [VarInt]       |
+   *                 +----------------------------+
+   *                 |       year [VarUInt]       |
+   *                 +----------------------------+
+   *                 :       month [VarUInt]      :
+   *                 +============================+
+   *                 :         day [VarUInt]      :
+   *                 +============================+
+   *                 :        hour [VarUInt]      :
+   *                 +====                    ====+
+   *                 :      minute [VarUInt]      :
+   *                 +============================+
+   *                 :      second [VarUInt]      :
+   *                 +============================+
+   *                 : fraction_exponent [VarInt] :
+   *                 +============================+
+   *                 : fraction_coefficient [Int] :
+   *                 +============================+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `Object` with offset, year, month, day, hour, minute, second, fractionExponent, and fractionCoefficient 
+   * properties
+   */
+  #readTimestamp = function (position, length, br) {
+    br.setPosition(position);
+
+    let remainingLength = length;
+    let offset;
+    let year;
+    let month;
+    let day;
+    let hour;
+    let minute;
+    let second;
+    let fractionExponent;
+    let fractionCoefficient;
+
+    // two mandatory components: offset and year
+    // TODO: warn if offset is less than -720 (-12 hours) or more than 840 (+14 hours)
+    //       warn if offset is more than 2 bytes (-8191, 8191) -^
+    offset = br.readVarInt();
+
+    // not enough bytes available, propagate null
+    if (offset === null) {
+      return null;
+    }
+
+    remainingLength -= offset.numBytesRead;
+
+    year = br.readVarUInt();
+
+    // not enough bytes available, propagate null
+    if (year === null) {
+      br.skipBytes(-1 * (length - remainingLength));
+      return null;
+    }
+
+    remainingLength -= year.numBytesRead;
+
+    if (remainingLength > 0) {
+      month = br.readVarUInt();
+
+      // not enough bytes available, propagate null
+      if (month === null) {
+        br.skipBytes(-1 * (length - remainingLength));
+        return null;
+      }
+
+      remainingLength -= month.numBytesRead;
+    }
+
+    // TODO: warn on days that are impossible (>31)
+    if (remainingLength > 0) {
+      day = br.readVarUInt();
+
+      // not enough bytes available, propagate null
+      if (day === null) {
+        br.skipBytes(-1 * (length - remainingLength));
+        return null;
+      }
+
+      remainingLength -= day.numBytesRead;
+    }
+
+    // hour and minute are considered a single component
+    if (remainingLength > 0) {
+      // TODO: warn on hours that are impossible (>24)
+      hour = br.readVarUInt();
+
+      // not enough bytes available, propagate null
+      if (hour === null) {
+        br.skipBytes(-1 * (length - remainingLength));
+        return null;
+      }
+
+      remainingLength -= hour.numBytesRead;
+
+      if (remainingLength > 0) {
+        // TODO: warn on minutes that are impossible (>60)
+        minute = br.readVarUInt();
+
+        // not enough bytes available, propagate null
+        if (minute === null) {
+          br.skipBytes(-1 * (length - remainingLength));
+          return null;
+        }
+
+        remainingLength -= minute.numBytesRead;
+      }
+      else {
+        // TODO: pass the error to the caller
+        const err = new Error(`ScalarValueReader hours present without minutes.`);
+        throw err;
+      }
+    }
+
+    if (remainingLength > 0) {
+      // TODO: warn on seconds that are impossible
+      second = br.readVarUInt();
+
+      // not enough bytes available, propagate null
+      if (second === null) {
+        br.skipBytes(-1 * (length - remainingLength));
+        return null;
+      }
+
+      remainingLength -= second.numBytesRead;
+    }
+
+    if (remainingLength > 0) {
+      fractionExponent = br.readVarInt();
+
+      // not enough bytes available, propagate null
+      if (fractionExponent === null) {
+        br.skipBytes(-1 * (length - remainingLength));
+        return null;
+      }
+
+      remainingLength -= fractionExponent.numBytesRead;
+    }
+
+    if (remainingLength > 0) {
+      fractionCoefficient = br.readInt(remainingLength);
+
+      // not enough bytes available, propagate null
+      if (fractionCoefficient=== null) {
+        br.skipBytes(-1 * (length - remainingLength));
+        return null;
+      }
+
+    // coefficient defaults to 0 if exponent exists and coefficient is not defined
+    } else if (fractionExponent !== undefined) {
+      fractionCoefficient = { numBytesRead: 0, magnitude: 0, isNegative: false };
+    }
+
+    return { offset: offset, year: year, month: month, day: day, hour: hour, minute: minute, second: second,
+             fractionExponent: fractionExponent, fractionCoefficient: fractionCoefficient };
+  };
+
+  /**
+   * Reads the representation (symbol ID) of a Symbol value.
+   * 
+   * @example
+   *               7       4 3       0
+   *              +---------+---------+
+   * Symbol value |   0x7   |    L    |
+   *              +---------+---------+======+
+   *              :     length [VarUInt]     :
+   *              +--------------------------+
+   *              |     symbol ID [UInt]     |
+   *              +--------------------------+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br 
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `Number` the Symbol ID
+   */
+  #readSymbol = function (position, length, br) {
+    if (length < 1) {
+      return 0;
+    }
+  
+    br.setPosition(position);
+
+    const symbol = br.readUInt(length);
+
+    // not enough bytes available, propagate null
+    if (symbol === null) {
+      return null;
+    }
+
+    return symbol.magnitude;
+  };
+
+  /**
+   * Reads the representation (UTF8) of a String value.
+   * 
+   * @example
+   *               7       4 3       0
+   *              +---------+---------+
+   * String value |   0x8   |    L    |
+   *              +---------+---------+======+
+   *              :     length [VarUInt]     :
+   *              +==========================+
+   *              :  representation [UTF8]   :
+   *              +==========================+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `String` the UTF8 string
+   */
+  #readString = function (position, length, br) {
+    const bytes = new Uint8Array(length);
+    br.setPosition(position);
+    for (let i = 0; i < length; ++i) {
+      bytes[i] = br.nextByte();
+
+      // not enough bytes available, propagate null
+      if (bytes[i] === null) {
+        br.skipBytes(-1 * i);
+        return null;
+      }
+    }
+
+    return this.#textDecoder.decode(bytes);
+  };
+
+  /**
+   * Reads the representation (data) of a Clob value.
+   * 
+   * @example
+   *             7       4 3       0
+   *            +---------+---------+
+   * Clob value |   0x9   |    L    |
+   *            +---------+---------+======+
+   *            :     length [VarUInt]     :
+   *            +==========================+
+   *            :       data [Bytes]       :
+   *            +==========================+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br 
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `Uint8Array` buffer of the Clob bytes
+   */
+  #readClob = function (position, length, br) {
+    const buffer = new Uint8Array(length);
+    br.setPosition(position);
+    for (let i = 0; i < length; ++i) {
+      buffer[i] = br.nextByte();
+
+      // not enough bytes available, propagate null
+      if (buffer[i] === null) {
+        br.skipBytes(-1 * i);
+        return null;
+      }
+    }
+
+    return buffer;
+  };
+
+  /**
+   * Reads the representation (data) of a Blob value.
+   * 
+   * @example
+   *             7       4 3       0
+   *            +---------+---------+
+   * Blob value |   0xA   |    L    |
+   *            +---------+---------+======+
+   *            :     length [VarUInt]     :
+   *            +==========================+
+   *            :       data [Bytes]       :
+   *            +==========================+
+   * 
+   * @param {Number} position 
+   * @param {Number} length 
+   * @param {ByteReader} br 
+   * @returns 
+   * - `null` if not enough bytes available to read the representation
+   * - `Uint8Array` buffer of the Blob bytes
+   */
+  #readBlob = function (position, length, br) {
+    const buffer = new Uint8Array(length);
+    br.setPosition(position);
+    for (let i = 0; i < length; ++i) {
+      buffer[i] = br.nextByte();
+
+      // not enough bytes available, propagate null
+      if (buffer[i] === null) {
+        br.skipBytes(-1 * i);
+        return null;
+      }
+    }
+
+    return buffer;
+  };
+
+  /**
+   * Maps IonTypes to scalar value reading functions.
+   */
+  #readScalarFuncs;
+
+  /**
+   * Requires a ByteReader as a parameter
+   * 
+   * @param {ByteReader} byteReader 
+   */
+  constructor (byteReader) {
+    if (!(byteReader instanceof br.ByteReader)) {
+      // TODO: pass the error to the caller
+      const err = new Error(`ScalarValueReader expected byteReader to be a ByteReader.`);
+      throw err;
+    }
+
+    this.#byteReader = byteReader;
+    this.#textDecoder = new TextDecoder("utf-8");
+
+    // initialize all functions to log an error
+    const self = this;
+    this.#readScalarFuncs = new Array(IonTypes.numTypes);
+    for (let i = 0; i < IonTypes.numTypes; ++i) {
+      this.#readScalarFuncs[i] = function (position, length) {
+        // TODO: pass the error to the caller
+        const err = new Error(`ScalarValueReader called on ${IonTypes.nameFromType(i)}, a non-scalar.`);
+        throw err;
+      };
+    }
+
+    // override the scalars with the proper functions
+    this.#readScalarFuncs[IonTypes["int+"]] = this.#readInt;
+    this.#readScalarFuncs[IonTypes["int-"]] = this.#readNegativeInt;
+    this.#readScalarFuncs[IonTypes["float"]] = this.#readFloat;
+    this.#readScalarFuncs[IonTypes["decimal"]] = this.#readDecimal;
+    this.#readScalarFuncs[IonTypes["timestamp"]] = this.#readTimestamp;
+    this.#readScalarFuncs[IonTypes["symbol"]] = this.#readSymbol;
+    this.#readScalarFuncs[IonTypes["string"]] = this.#readString;
+    this.#readScalarFuncs[IonTypes["clob"]] = this.#readClob;
+    this.#readScalarFuncs[IonTypes["blob"]] = this.#readBlob;
+  }
+
+  /**
+   * Reads a specified scalar value type from a specified position in the byte reader that is the specified length.
+   * 
+   * @param {IonType} type 
+   * @param {Number} position 
+   * @param {Number} length 
+   */
+  read(type, position, length) {
+    if (this.#readScalarFuncs[type] === undefined) {
+      // TODO: pass the error to the caller
+      const err = new Error(`ScalarValueReader read() called with non-existant type ${type}.`);
+      throw err;
+    }
+
+    if (!Number.isInteger(position) || position < 0) {
+      // TODO: pass the error to the caller
+      const err = new Error(`ScalarValueReader read() called with invalid position ${position}.`);
+      throw err;
+    }
+
+    if (!Number.isInteger(length) || length <= 0) {
+      // TODO: pass the error to the caller
+      const err = new Error(`ScalarValueReader read() called with invalid length ${length}.`);
+      throw err;
+    }
+    
+    return this.#readScalarFuncs[type].apply(this, [position, length, this.#byteReader]);
+  }
+}
+
+/**
+ * Helper function to read scalar values from an IonElement.  
+ * Requires an IonElement as a parameter.  
+ * Requires a ScalarValueReader as a parameter.
+ * 
+ * @param {IonElement} element 
+ * @param {ScalarValueReader} scalarReader 
+ * @returns 
+ */
+const readScalarFromElement = (element, scalarReader) => {
+  if (element === undefined || scalarReader === null) {
+    const err = new Error(`readScalar called with no element`);
+    throw err;
+  }
+
+  if (scalarReader === undefined || scalarReader === null) {
+    const err = new Error(`readScalar called with no scalarReader`);
+    throw err;
+  }
+
+  return scalarReader.read(
+    element.type, element.bytePositionOfRepresentation, (element.lengthWithoutAnnotations - element.varUIntLength)
+  );
+};
+
+exports.readScalarFromElement = readScalarFromElement;
+exports.ScalarValueReader = ScalarValueReader;

--- a/test/core/ElementReference.spec.js
+++ b/test/core/ElementReference.spec.js
@@ -1,0 +1,115 @@
+const { assert } = require('chai');
+const er = require("../../src/core/ElementReference");
+
+describe('ElementReference', function() {
+  describe("createElementReference()", function () {
+    it('should return an array with the element reference properties', function() {
+      let ref = er.createElementReference();
+      const refEmpty = [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined ];
+      assert.deepEqual(ref, refEmpty);
+      ref = er.createElementReference(0, 1, 2, 3, 4, 5, 6);
+      const refNotEmpty = [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ];
+      assert.deepEqual(ref, refNotEmpty);
+    });
+  });
+  describe("isElementReference()", function () {
+    it('should return false for non element references', function() {
+      const refEmptyObject = {};
+      assert.isFalse(er.isElementReference(refEmptyObject));
+      const refNumber = 4;
+      assert.isFalse(er.isElementReference(refNumber));
+      const refEmptyArray = [];
+      assert.isFalse(er.isElementReference(refEmptyArray));
+      const refArrayWith3Elements = [0, 1, 2];
+      assert.isFalse(er.isElementReference(refArrayWith3Elements));
+      const refArrayWith6Elements = [0, 1, 2, 3, 4, 5];
+      assert.isFalse(er.isElementReference(refArrayWith6Elements));
+      const refArrayWith8Elements = [0, 1, 2, 3, 4, 5, 6, 7];
+      assert.isFalse(er.isElementReference(refArrayWith8Elements));
+    });
+    it('should return true for element references', function () {
+      const refHandCraftedUndefined = [
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      ];
+      const refHandCraftedNumbers = [
+        0,
+        1,
+        2,
+        3,
+        4,
+        5,
+        6
+      ];
+      const refHelperCreatedUndefined = er.createElementReference();
+      const refHelperCreatedPartial = er.createElementReference(0, 1, 2);
+      const refHelperCreatedComplete = er.createElementReference(0, 1, 2, 3, 4, 5, 6);
+      assert.isTrue(er.isElementReference(refHandCraftedUndefined));
+      assert.isTrue(er.isElementReference(refHandCraftedNumbers));
+      assert.isTrue(er.isElementReference(refHelperCreatedUndefined));
+      assert.isTrue(er.isElementReference(refHelperCreatedPartial));
+      assert.isTrue(er.isElementReference(refHelperCreatedComplete));
+    });
+  });
+  describe("nextElementReference()", function () {
+    it('should return null or undefined if there is no next element', function () {
+      const refUndefined = er.createElementReference();
+      const refUndefinedNext = er.createElementReference(0, 1, 2, 3, 4, 5);
+      const refNullNext = er.createElementReference(0, 1, 2, 3, 4, 5, null);
+      assert.deepEqual(er.nextElementReference(refUndefined), undefined);
+      assert.deepEqual(er.nextElementReference(refUndefinedNext), undefined);
+      assert.deepEqual(er.nextElementReference(refNullNext), null);
+    });
+    it('should throw if next absolute offset is at or before stream offset', function () {
+      const erNextAt2Depth0 = er.createElementReference(0, 5, 0, 2, undefined, undefined, 2);
+      assert.throws(() => { er.nextElementReference(erNextAt2Depth0); }, 
+                          "ElementReference nextElementReference absolute next offset (2) <= stream offset + relative offset (0 + 5)" );
+    });
+    it('should return an ElementReference if there is a next element', function () {
+      const erNextAt6Depth0 = er.createElementReference(0, 5, 0, 2, undefined, undefined, 6);
+      const refNextAt6Depth0 = er.nextElementReference(erNextAt6Depth0);
+      const erPos6Depth0 = [
+        0, 6, 0, 1, undefined, undefined, undefined
+      ];
+      assert.deepEqual(refNextAt6Depth0, erPos6Depth0);
+      assert.isTrue(er.isElementReference(refNextAt6Depth0));
+
+      const erNextAt6Depth2 = er.createElementReference(123, 5, 2, 100, 80, 11, 129);
+      const refNextAt6Depth2 = er.nextElementReference(erNextAt6Depth2);
+      const erPos6Depth2 = [
+        123, 6, 2, 99, 80, 11, undefined
+      ];
+      assert.deepEqual(refNextAt6Depth2, erPos6Depth2);
+      assert.isTrue(er.isElementReference(refNextAt6Depth2));
+    });
+  });
+  describe("absoluteOffset()", function () {
+    it('should return a number that is the fileOffset + relativeOffset', function () {
+      const erOffset5 = er.createElementReference(0, 5, undefined, undefined, undefined, undefined, undefined);
+      assert.strictEqual(er.absoluteOffset(erOffset5), 5);
+      
+      const erOffset128 = er.createElementReference(123, 5, undefined, undefined, undefined, undefined, undefined);
+      assert.strictEqual(er.absoluteOffset(erOffset128), 128);
+    });
+  });
+});

--- a/test/core/IonElement.spec.js
+++ b/test/core/IonElement.spec.js
@@ -1,0 +1,640 @@
+const { assert } = require('chai');
+const tdr = require("../../src/core/TypeDescriptorReader");
+const br = require('../../src/core/ByteReader');
+const bbr = require('../../src/core/ByteBufferReader');
+const types = require('../../src/core/IonTypes');
+const ie = require('../../src/core/IonElement');
+const er = require('../../src/core/ElementReference');
+const { IonTypes } = require('../../src/core/IonTypes');
+let tdReader;
+
+// 0xE0 01 00 EA (BVM)
+const bvmBuf = [parseInt('0xE0', 16), parseInt('0x01', 16), parseInt('0x00', 16), parseInt('0xEA', 16)];
+
+// 0x21 FF (int+ 255)
+// 0x20    (int+ 0)
+const intBuf = [parseInt('0x21', 16), parseInt('0xFF', 16), parseInt('0x20', 16)];
+
+const createReader = (reader) => {
+  return new tdr.TypeDescriptorReader(reader);
+};
+
+const createBufferByteReader = (hexToTest) => {
+  const buf = new Uint8Array(hexToTest);
+  const byteReader = new bbr.ByteBufferReader();
+  byteReader.loadBuffer(buf);
+  return byteReader;
+};
+
+const createNibbleStruct = () => {
+  return {
+    annotation: {},
+    depth: 0,
+    element: {
+      lengthValue: 0,
+      nibbles: {
+        lengthEnd: 1,
+        lengthStart: 1,
+        type: 0
+      },
+      totalLength: 0,
+      typeName: "",
+      typeValue: 0
+    },
+    fieldName: null,
+    offset: 0,
+    totalNibbles: 1
+  };
+};
+
+describe('IonElement', function() {
+  describe("constructor", function () {
+    it('should error when not passed an ElementReference', function() {
+      let element;
+      assert.throws(() => 
+                    { element = new ie.IonElement(); },
+                    Error);
+
+      assert.throws(() => 
+                    { element = new ie.IonElement(0); }, 
+                    Error);
+
+      assert.throws(() => 
+                    { element = new ie.IonElement([0, 0, 0, 0, 0, 0]); }, 
+                    Error);
+
+      assert.doesNotThrow(() => 
+                    { element = new ie.IonElement(er.createElementReference(0, 0, 0, 0, 0, IonTypes["list"], 0)); });
+    });
+    it('should succeed when passed all parameters', function() {
+      const containerType = IonTypes["struct"];
+      const containerOffset = 0;
+      const fileOffset = 1;
+      const positionInStream = 5;
+      const depth = 4;
+      const bytesRemainingAtDepth = 3;
+      const next = null;
+      const reference = er.createElementReference(fileOffset, positionInStream, depth, bytesRemainingAtDepth, 
+                                                containerOffset, containerType, next);
+      const element = new ie.IonElement(reference);
+      assert.strictEqual(element.absoluteOffset, fileOffset+positionInStream);
+      assert.strictEqual(element.relativeOffset, positionInStream);
+      assert.strictEqual(element.depth, depth);
+      assert.strictEqual(element.bytesRemainingAtDepth, bytesRemainingAtDepth);
+      assert.strictEqual(element.container, containerOffset);
+      assert.strictEqual(element.containerType, containerType);
+      assert.strictEqual(element.nextElementReference, next);
+    });
+  });
+  describe("readTypeDescriptor", function () {
+    it('should fail when called with no bytes remaining at depth', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 0, null, null, null));
+      assert.throws(() => { 
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(bvmBuf))); },
+                    Error);
+    });
+    it('should read BVM and set as system element', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(bvmBuf)), "bvm");
+      assert.strictEqual(element.depth, 0);
+      assert.strictEqual(element.isSystemElement, true);
+    });
+    it('should fail when BVM appears at depth greater than zero', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 1, 4, null, null, null));
+      assert.throws(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(bvmBuf)), "bvm"),
+        Error });
+    });
+    it('should fail when passed BVM context for non-BVM value', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 3, null, null, null));
+      assert.throws(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(intBuf)), "bvm"),
+        Error });
+    });
+    it('should create the next element if there are bytes remaining', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 3, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(intBuf)), "1_0");
+      assert.equal(element.nextElementReference !== null, true);
+      assert.equal(element.nextElementReference[1], 2);
+    });
+    it('should not create a next element if there are no bytes remaining', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0x20 (int+ 0)
+            [parseInt('0x20', 16)])), "1_0");
+      assert.strictEqual(element.nextElementReference, null);
+    });
+    it('should create a child element for container elements', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 2, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0xB1 00 (1 byte empty list [])
+            [parseInt('0xB1', 16), parseInt('0x00', 16)])), "1_0");
+      assert.notStrictEqual(element.containsElement, null);
+      assert.equal(element.containsElement[1], 1);
+    });
+    it('should not create child elements for non-container elements', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0x20 (int+ 0)
+            [parseInt('0x20', 16)])), "1_0");
+      assert.strictEqual(element.containsElement, null);
+    });
+    it('should read elements properly if in a struct', function () {
+      const reader = createReader(
+        createBufferByteReader(
+          // D3 81 81 30 (3 byte struct { $ion:"0" })
+          [parseInt('0xD3', 16), parseInt('0x81', 16), parseInt('0x81', 16), parseInt('0x30', 16)]));
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      const element = new ie.IonElement(er.createElementReference(0, 1, 1, 3, 0, IonTypes["struct"], null));
+      element.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(structElement.type, IonTypes["struct"]);
+      assert.strictEqual(structElement.length, 3);
+      assert.strictEqual(element.type, IonTypes["string"]);
+      assert.strictEqual(element.container, structElement.relativeOffset);
+      assert.strictEqual(element.depth, 1);
+      assert.strictEqual(element.fieldNameSymbolID, 1);
+      assert.strictEqual(element.isSystemElement, false);
+      assert.strictEqual(element.annotationsLength, 0);
+    });
+    it('should set struct element with NOP value as system element', function () {
+      let reader = createReader(
+        createBufferByteReader(
+          // D3 80 01 AC (empty struct with three bytes of padding)
+          [parseInt('0xD3', 16), parseInt('0x80', 16), parseInt('0x01', 16), parseInt('0xAC', 16)]));
+      let structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      let element = new ie.IonElement(er.createElementReference(0, 1, 1, 3, 0, IonTypes["struct"], null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      element.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(structElement.type, IonTypes["struct"]);
+      assert.strictEqual(element.type, IonTypes["nop"]);
+      assert.strictEqual(element.container, structElement.relativeOffset);
+      assert.strictEqual(element.isSystemElement, true);
+
+      reader = createReader(
+        createBufferByteReader(
+          // D2 8F 00 (empty struct with two bytes of padding)
+          [parseInt('0xD2', 16), parseInt('0x8F', 16), parseInt('0x00', 16)]));
+      structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 3, null, null, null));
+      element = new ie.IonElement(er.createElementReference(0, 1, 1, 2, 
+                                                           structElement.relativeOffset, IonTypes["struct"], null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      element.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(structElement.type, IonTypes["struct"]);
+      assert.strictEqual(element.type, IonTypes["nop"]);
+      assert.strictEqual(element.container, structElement.relativeOffset);
+      assert.strictEqual(element.isSystemElement, true);
+    });
+    it('should set sorted flag for sorted structs', function () {
+      const reader = createReader(
+        createBufferByteReader(
+          // D1 83 81 81 30 (3 byte struct { $ion:"0" })
+          [parseInt('0xD1', 16), parseInt('0x83', 16), parseInt('0x81', 16), parseInt('0x81', 16), parseInt('30', 16)]));
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 5, null, null, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(structElement.type, IonTypes["struct"]);
+      assert.strictEqual(structElement.isSorted, true);
+    });
+    it('should fail when sorted struct is empty', function () {
+      const reader = createReader(
+        createBufferByteReader(
+          // D1 80 01 AC (empty sorted struct with length 0 and two bytes of padding)
+          [parseInt('0xD1', 16), parseInt('0x80', 16), parseInt('0x01', 16), parseInt('AC', 16)]));
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      assert.throws(() => {
+        structElement.readTypeDescriptor(reader, "1_0");
+        }, Error);
+
+      // TODO: create this test in DOM and Value 
+      // D1 82 01 AC (empty sorted struct with length 2 and two bytes of padding)
+      // [parseInt('0xD1', 16), parseInt('0x82', 16), parseInt('0x01', 16), parseInt('AC', 16)]
+    });
+    it('should set shared system tables at depth 0 as system elements', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      assert.doesNotThrow(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(
+              // E3 81 89 D0 (3 byte annotation wrapping 0 byte struct ($ion_shared_symbol_table::{}))
+              [parseInt('0xE3', 16), parseInt('0x81', 16), parseInt('0x89', 16),
+               parseInt('0xD0', 16)])), "1_0"); });
+      
+      assert.strictEqual(element.annotationsLength, 1);
+      assert.strictEqual(element.type, IonTypes["struct"]);
+      assert.strictEqual(element.isSystemElement, true);
+    });
+    it('should set local system tables at depth 0 as system elements', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      assert.doesNotThrow(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(
+              // E3 81 83 D0 (3 byte annotation wrapping 0 byte struct ($ion_shared_symbol_table::{}))
+              [parseInt('0xE3', 16), parseInt('0x81', 16), parseInt('0x83', 16),
+               parseInt('0xD0', 16)])), "1_0"); });
+      
+      assert.strictEqual(element.annotationsLength, 1);
+      assert.strictEqual(element.type, IonTypes["struct"]);
+      assert.strictEqual(element.isSystemElement, true);
+    });
+    it('should warn when symbol tables appear at depth greater than 0', function () {
+      const reader = createReader(
+        createBufferByteReader(
+          // D4 81 E3 81 89 D0 ({$ion: $ion_shared_symbol_table::{}})
+          [parseInt('0xD4', 16), parseInt('0x81', 16), parseInt('0xE3', 16), parseInt('0x81', 16),
+            parseInt('0x89', 16), parseInt('0xD0', 16)]));
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 6, null, null, null));
+      const element = new ie.IonElement(er.createElementReference(0, 1, 15, 5, structElement.relativeOffset, 
+                                                                IonTypes["struct"], null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      assert.throws(() => {
+        element.readTypeDescriptor(reader, "1_0"); },
+        Error);
+      
+      assert.strictEqual(structElement.type, IonTypes["struct"]);
+      assert.strictEqual(element.isSystemElement, false);
+    });
+    it('should fail when annotations wrap other annotations', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 6, null, null, null));
+      assert.throws(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(
+              // E6 81 81 E3 81 81 80 (1 byte annotation wrapping 3 byte annotation ($ion::$ion::""))
+              [parseInt('0xE6', 16), parseInt('0x81', 16), parseInt('0x81', 16),
+               parseInt('0xE3', 16), parseInt('0x81', 16), parseInt('0x81', 16), parseInt('0x80', 16)])), "1_0"); },
+              Error);
+    });
+    it('should set annotation wrapper and read element inside of wrapper', function () {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 7, null, null, null));
+      assert.doesNotThrow(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(
+              // E6 81 81 D3 81 81 30 (1 byte annotation wrapping 3 byte struct ($ion::{$ion:"0"}))
+              [parseInt('0xE6', 16), parseInt('0x81', 16), parseInt('0x81', 16),
+               parseInt('0xD3', 16), parseInt('0x81', 16), parseInt('0x81', 16), parseInt('0x30', 16)])), "1_0"); });
+      
+      assert.strictEqual(element.annotationsLength, 1);
+      assert.strictEqual(element.type, IonTypes["struct"]);
+      assert.strictEqual(element.length, 6);
+    });
+    it('should fail when annotations wrap NOPs', function () {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      assert.throws(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(
+              // 0xE3 0x81 0x84 0x00
+              [parseInt('0xE3', 16), parseInt('0x81', 16),
+               parseInt('0x84', 16), parseInt('0x00', 16)])), "1_0"); },
+              Error);
+    });
+    it('should fail when annotations wrap NOP elements', function () {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      assert.throws(() => {
+        element.readTypeDescriptor(
+          createReader(
+            createBufferByteReader(
+              // E4 81 84 02 FF (3 byte annotation wrapping 2 byte NOP)
+              [parseInt('0xE4', 16), parseInt('0x81', 16), parseInt('0x84', 16), 
+               parseInt('0x02', 16), parseInt('0xFF', 16)])), "1_0"); },
+              Error);
+      
+      const reader = createReader(
+        createBufferByteReader(
+          // D5 80 E3 81 84 00 ({$0:name::1 byte NOP})
+          [parseInt('0xD5', 16), parseInt('0x80', 16), parseInt('0xE3', 16), parseInt('0x81', 16),
+          parseInt('0x84', 16), parseInt('0x00', 16)]), "1_0");
+      let structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 6, null, null, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      element = new ie.IonElement(er.createElementReference(0, 1, 1, 5, structElement.absoluteOffset, 
+                                                            IonTypes["struct"], null));
+      assert.throws(() => {
+        element.readTypeDescriptor(reader, "1_0"); },
+              Error);
+    });
+    it('should set NOPs as system elements', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0x00 (1 byte NOP)
+            [parseInt('0x00', 16)])), "1_0");
+      assert.strictEqual(element.type, IonTypes["nop"]);
+      assert.strictEqual(element.isSystemElement, true);
+    });
+    it('should read nested containers', function () {
+      const reader = createReader(
+        createBufferByteReader(
+          // $ion_symbol_table::{
+          //   symbols: ["age", "years"] 
+          // }
+          // 17 byte (0x91) annotation wrapper
+          //   1 byte (0x81) annot_length
+          //     (0x83) $ion_symbol_table::
+          //   13 byte (0x8D) (doesn't need separate length) struct
+          //     (0x87) field name: symbols
+          //     10 byte (0x8A) (doesn't need separate length) list 
+          //       3 byte (0x83) string: age
+          //       5 byte (0x85) string: years
+          // EE 91 81 83 DE 8D 87 BE A2 83 61 67 65 85 79 65 61 72 73
+          [parseInt('0xEE', 16), parseInt('0x91', 16), parseInt('0x81', 16), parseInt('0x83', 16),
+           parseInt('0xDE', 16), parseInt('0x8D', 16), parseInt('0x87', 16), parseInt('0xBE', 16),
+           parseInt('0x8A', 16), parseInt('0x83', 16), parseInt('0x61', 16), parseInt('0x67', 16),
+           parseInt('0x65', 16), parseInt('0x85', 16), parseInt('0x79', 16), parseInt('0x65', 16),
+           parseInt('0x61', 16), parseInt('0x72', 16), parseInt('0x73', 16)]));
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 19, null, null, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(structElement.type, IonTypes["struct"]);
+      assert.strictEqual(structElement.annotationsLength, 1);
+      assert.strictEqual(structElement.isSystemElement, true);
+      assert.strictEqual(structElement.length, 18);
+
+      const listElement = new ie.IonElement(er.createElementReference(0, structElement.bytePositionOfRepresentation, 1,
+                                                                    15, structElement.relativeOffset,
+                                                                    IonTypes["struct"], null));
+      listElement.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(listElement.type, IonTypes["list"]);
+      assert.strictEqual(listElement.length, 11);
+
+      const ageStringElement = new ie.IonElement(er.createElementReference(0, listElement.bytePositionOfRepresentation, 2,
+                                                                         listElement.lengthWithoutAnnotations - 1,
+                                                                         listElement.relativeOffset, IonTypes["list"],
+                                                                         null));
+      ageStringElement.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(ageStringElement.type, IonTypes["string"]);
+
+      const yearsStringElement = new ie.IonElement(er.createElementReference(0, ageStringElement.nextElementReference[1],
+                                                                           2, (ageStringElement.bytesRemainingAtDepth - 
+                                                                           ageStringElement.length + 1),
+                                                                           listElement.relativeOffset, IonTypes["list"], 
+                                                                           ageStringElement.relativeOffset));
+      yearsStringElement.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(yearsStringElement.type, IonTypes["string"]);
+    });
+  });
+  describe("getBytePositionOfRepresentation", function () {
+    it('should return null for byte position of bvm and nop values', function () {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      let reader = createReader(createBufferByteReader(bvmBuf));
+      element.readTypeDescriptor(reader, "bvm");
+      assert.strictEqual(element.type, IonTypes["bvm"]);
+      assert.strictEqual(element.bytePositionOfRepresentation, null);
+
+      element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      reader = createReader(createBufferByteReader([parseInt('0x00', 16)]));
+      element.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(element.type, IonTypes["nop"]);
+      assert.strictEqual(element.bytePositionOfRepresentation, null);
+    });
+    it('should return null for byte position of representation of null values', function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0x2F (int+ null)
+            [parseInt('0x2F', 16)])), "1_0");
+      assert.strictEqual(element.bytePositionOfRepresentation, null);
+    });
+    it('should return null for byte position of representation of 0 length values', function () {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0x20 (int+ 0)
+            [parseInt('0x20', 16)])), "1_0");
+      assert.strictEqual(element.bytePositionOfRepresentation, null);
+
+      element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0xD0 ({})
+            [parseInt('0xD0', 16)])), "1_0");
+      assert.strictEqual(element.bytePositionOfRepresentation, null);
+
+      element = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // E3 81 89 D0 (3 byte annotation wrapping 0 byte struct ($ion::{}))
+            [parseInt('0xE3', 16), parseInt('0x81', 16), parseInt('0x81', 16),
+              parseInt('0xD0', 16)])), "1_0");
+              // should fail
+      assert.strictEqual(element.bytePositionOfRepresentation, null);
+    });
+    it('should return byte position of representation without annotations', function () {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 2, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 21 FF (1 byte positive int 255)
+            [parseInt('0x21', 16), parseInt('0xFF', 16)])), "1_0");
+      assert.strictEqual(element.bytePositionOfRepresentation, 1);
+      assert.strictEqual(element.bytePositionOfAnnotations, null);
+
+      element = new ie.IonElement(er.createElementReference(0, 0, 0, 16, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // VarUInt (8E = 14) byte positive int
+            // 5192296858534827628530496329220095
+            // 2E 8E FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+            [parseInt('0x2E', 16), parseInt('0x8E', 16),
+             parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+             parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+             parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)])), "1_0");
+      assert.strictEqual(element.bytePositionOfRepresentation, 2);
+      assert.strictEqual(element.bytePositionOfAnnotations, null);
+    });
+    it('should return byte position of representation with annotations', function() {
+      let element = new ie.IonElement(er.createElementReference(0, 0, 0, 5, null, null, null));
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // E4 81 81 81 30 (4 byte annotation wrapper ($ion::"0"))
+            [parseInt('0xE4', 16), parseInt('0x81', 16), parseInt('0x81'),
+             parseInt('0x81', 16), parseInt('0x30', 16)])), "1_0");
+      assert.strictEqual(element.bytePositionOfRepresentation, 4);
+      assert.strictEqual(element.bytePositionOfAnnotations, 2);
+
+      const reader = createReader(
+        createBufferByteReader(
+          // E3 81 89 D2 81 21 FF (3 byte annotation wrapping 2 byte struct ($ion_shared_symbol_table::{$ion:255}))
+          [parseInt('0xE6', 16), parseInt('0x81', 16), parseInt('0x89', 16),
+            parseInt('0xD2', 16), parseInt('0x81', 16), parseInt('0x21', 16), parseInt('0xFF', 16)]));
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 7, null, null, null));
+      element = new ie.IonElement(er.createElementReference(0, 5, 1, 3, structElement.relativeOffset, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      element.readTypeDescriptor(reader, "1_0");
+      assert.strictEqual(structElement.bytePositionOfRepresentation, 4);
+      assert.strictEqual(structElement.bytePositionOfAnnotations, 2);
+      assert.strictEqual(element.bytePositionOfRepresentation, 6);
+      assert.strictEqual(element.bytePositionOfAnnotations, null);
+    });
+    // TODO: add test for bytePositionOfAnnotations when there is a fieldName as well
+  });
+  describe("getNibblePositionStruct", function () {
+    it("should return nibble positions for empty struct", function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 1, null, null, null));
+      const nibbleStruct = createNibbleStruct();
+      nibbleStruct.element.totalLength = 1;
+      nibbleStruct.element.typeName = "struct";
+      nibbleStruct.element.typeValue = IonTypes["struct"];
+      nibbleStruct.totalNibbles = 2;
+
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // 0xD0 ({})
+            [parseInt('0xD0', 16)])), "1_0");
+      assert.deepEqual(element.nibblePositionStruct, nibbleStruct);
+    });
+    it("should return nibble positions for VarUInt length values", function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 16, null, null, null));
+      const nibbleStruct = createNibbleStruct();
+      nibbleStruct.element.lengthValue = 14;
+      nibbleStruct.element.nibbles.lengthEnd = 3;
+      nibbleStruct.element.nibbles.representationStart = 4;
+      nibbleStruct.element.nibbles.representationEnd = 31;
+      nibbleStruct.element.totalLength = 16;
+      nibbleStruct.element.typeName = "int+";
+      nibbleStruct.element.typeValue = IonTypes["int+"];
+      nibbleStruct.totalNibbles = 32;
+
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // VarUInt (8E = 14) byte positive int
+            // 5192296858534827628530496329220095
+            // 2E 8E FF FF FF FF FF FF FF FF FF FF FF FF FF FF
+            [parseInt('0x2E', 16), parseInt('0x8E', 16),
+             parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+             parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+             parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)])), "1_0");
+      assert.deepEqual(element.nibblePositionStruct, nibbleStruct);
+    });
+    it("should return nibble positions for values with one annotation", function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 5, null, null, null));
+      const nibbleStruct = createNibbleStruct();
+      nibbleStruct.annotation.lengthValue = 1;
+      nibbleStruct.annotation.annotations = [];
+      nibbleStruct.annotation.annotations.push({ nibbles: { symbolStart: 4, symbolEnd: 5 }, symbolMagnitude: 1 });
+      nibbleStruct.annotation.nibbles = { type: 0, wrapperLengthStart: 1, wrapperLengthEnd: 1, annotationsLengthStart: 2, annotationsLengthEnd: 3 };
+      nibbleStruct.annotation.wrapperLengthValue = 4;
+      nibbleStruct.element.lengthValue = 1;
+      nibbleStruct.element.nibbles = { type: 6, lengthStart: 7, lengthEnd: 7, representationStart: 8, representationEnd: 9 };
+      nibbleStruct.element.totalLength = 5;
+      nibbleStruct.element.typeName = "string";
+      nibbleStruct.element.typeValue = IonTypes["string"];
+      nibbleStruct.totalNibbles = 10;
+
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // E4 81 81 81 30 (4 byte annotation wrapper ($ion::"0"))
+            [parseInt('0xE4', 16), parseInt('0x81', 16), parseInt('0x81'),
+             parseInt('0x81', 16), parseInt('0x30', 16)])), "1_0");
+      assert.deepEqual(element.nibblePositionStruct, nibbleStruct);
+    });
+    it("should return nibble positions for values with multiple annotations", function () {
+      const element = new ie.IonElement(er.createElementReference(0, 0, 0, 20, null, null, null));
+      const nibbleStruct = createNibbleStruct();
+      nibbleStruct.annotation.lengthValue = 15;
+      nibbleStruct.annotation.annotations = [];
+      nibbleStruct.annotation.annotations.push({ nibbles: { symbolStart: 6, symbolEnd: 7 }, symbolMagnitude: 127 });
+      nibbleStruct.annotation.annotations.push({ nibbles: { symbolStart: 8, symbolEnd: 11 }, symbolMagnitude: 16383 });
+      nibbleStruct.annotation.annotations.push({ nibbles: { symbolStart: 12, symbolEnd: 17 }, symbolMagnitude: 2097151 });
+      nibbleStruct.annotation.annotations.push({ nibbles: { symbolStart: 18, symbolEnd: 25 }, symbolMagnitude: 268435455 });
+      nibbleStruct.annotation.annotations.push({ nibbles: { symbolStart: 26, symbolEnd: 35 }, symbolMagnitude: 34359738367 });
+      nibbleStruct.annotation.nibbles = { type: 0, wrapperLengthStart: 1, wrapperLengthEnd: 3, annotationsLengthStart: 4, annotationsLengthEnd: 5 };
+      nibbleStruct.annotation.wrapperLengthValue = 19;
+      nibbleStruct.element.lengthValue = 1;
+      nibbleStruct.element.nibbles = { type: 36, lengthStart: 37, lengthEnd: 37, representationStart: 38, representationEnd: 39 };
+      nibbleStruct.element.totalLength = 20;
+      nibbleStruct.element.typeName = "string";
+      nibbleStruct.element.typeValue = IonTypes["string"];
+      nibbleStruct.totalNibbles = 40;
+
+      element.readTypeDescriptor(
+        createReader(
+          createBufferByteReader(
+            // EE 91 8F FF 7F FF 7F 7F FF 7F 7F 7F FF 7F 7F 7F 7F FF 81 30 (18 byte annotation wrapper ($ion::"0"))
+            // $127::$16383::$2097151::$268435455::$34359738367::"0"
+            [parseInt('0xEE', 16), parseInt('0x92', 16), // T/L
+             parseInt('0x8F'), // annot_length
+             parseInt('0xFF'), // 127
+             parseInt('0x7F'), parseInt('0xFF'), // 16,383
+             parseInt('0x7F'), parseInt('0x7F'), parseInt('0xFF'), // 2,097,151
+             parseInt('0x7F'), parseInt('0x7F'), parseInt('0x7F'), parseInt('0xFF'), // 268,435,455
+             parseInt('0x7F'), parseInt('0x7F'), parseInt('0x7F'), parseInt('0x7F'), parseInt('0xFF'), // 34,359,738,367
+             parseInt('0x81', 16), parseInt('0x30', 16)])), "1_0");
+      assert.deepEqual(element.nibblePositionStruct, nibbleStruct);
+    });
+    it("should return nibble positions for nop element with field name", function () {
+      const nibbleStruct = createNibbleStruct();
+      nibbleStruct.depth = 1;
+      nibbleStruct.fieldName = { symbolMagnitude: 0, nibbles: { symbolStart: 0, symbolEnd: 1 }};
+      nibbleStruct.element.lengthValue = 1;
+      nibbleStruct.element.nibbles = { type: 2, lengthStart:3, lengthEnd:3, representationStart: 4, representationEnd: 5 };
+      nibbleStruct.element.totalLength = 3;
+      nibbleStruct.element.typeName = "nop";
+      nibbleStruct.element.typeValue = IonTypes["nop"];
+      nibbleStruct.offset = 1;
+      nibbleStruct.totalNibbles = 6;
+
+      const reader = createReader(
+        createBufferByteReader(
+          // D3 80 01 FF (empty struct - with 3 bytes of padding)
+          [parseInt('0xD3', 16), parseInt('0x80'), parseInt('0x01'), parseInt('0xFF')]));
+  
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 4, null, null, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      const element = new ie.IonElement(er.createElementReference(0, 1, 1, 3, structElement.relativeOffset,
+                                                                IonTypes["struct"], null));
+      element.readTypeDescriptor(reader, "1_0");
+      assert.deepEqual(element.nibblePositionStruct, nibbleStruct);
+    });
+    it("should return nibble positions for element with field name > 127", function () {
+      const nibbleStruct = createNibbleStruct();
+      nibbleStruct.depth = 1;
+      nibbleStruct.fieldName = { symbolMagnitude: 128, nibbles: { symbolStart: 0, symbolEnd: 3 }};
+      nibbleStruct.element.lengthValue = 1;
+      nibbleStruct.element.nibbles = { type: 4, lengthStart:5, lengthEnd:5, representationStart: 6, representationEnd: 7 };
+      nibbleStruct.element.totalLength = 4;
+      nibbleStruct.element.typeName = "nop";
+      nibbleStruct.element.typeValue = IonTypes["nop"];
+      nibbleStruct.offset = 1;
+      nibbleStruct.totalNibbles = 8;
+
+      const reader = createReader(
+        createBufferByteReader(
+          // D3 01 80 01 FF (empty struct - with 4 bytes of padding)
+          [parseInt('0xD3', 16), parseInt('0x01'), parseInt('0x80'), parseInt('0x01'), parseInt('0xFF')]));
+  
+      const structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 5, null, null, null));
+      structElement.readTypeDescriptor(reader, "1_0");
+      const element = new ie.IonElement(er.createElementReference(0, 1, 1, 4, structElement.relativeOffset,
+                                                                IonTypes["struct"], null));
+      element.readTypeDescriptor(reader, "1_0");
+      assert.deepEqual(element.nibblePositionStruct, nibbleStruct);
+    });
+  });
+});

--- a/test/core/IonElement.spec.js
+++ b/test/core/IonElement.spec.js
@@ -108,16 +108,16 @@ describe('IonElement', function() {
       assert.throws(() => {
         element.readTypeDescriptor(
           createReader(
-            createBufferByteReader(bvmBuf)), "bvm"),
-        Error });
+            createBufferByteReader(bvmBuf)), "bvm"); },
+        Error);
     });
     it('should fail when passed BVM context for non-BVM value', function () {
       const element = new ie.IonElement(er.createElementReference(0, 0, 0, 3, null, null, null));
       assert.throws(() => {
         element.readTypeDescriptor(
           createReader(
-            createBufferByteReader(intBuf)), "bvm"),
-        Error });
+            createBufferByteReader(intBuf)), "bvm"); },
+        Error);
     });
     it('should create the next element if there are bytes remaining', function () {
       const element = new ie.IonElement(er.createElementReference(0, 0, 0, 3, null, null, null));
@@ -321,7 +321,7 @@ describe('IonElement', function() {
         createBufferByteReader(
           // D5 80 E3 81 84 00 ({$0:name::1 byte NOP})
           [parseInt('0xD5', 16), parseInt('0x80', 16), parseInt('0xE3', 16), parseInt('0x81', 16),
-          parseInt('0x84', 16), parseInt('0x00', 16)]), "1_0");
+          parseInt('0x84', 16), parseInt('0x00', 16)]));
       let structElement = new ie.IonElement(er.createElementReference(0, 0, 0, 6, null, null, null));
       structElement.readTypeDescriptor(reader, "1_0");
       element = new ie.IonElement(er.createElementReference(0, 1, 1, 5, structElement.absoluteOffset, 

--- a/test/core/ScalarValueReader.spec.js
+++ b/test/core/ScalarValueReader.spec.js
@@ -17,8 +17,8 @@ describe('ScalarValueReader', function() {
       const byteReader = new br.ByteReader();
       assert.doesNotThrow(() => { scalarValueReader = new svr.ScalarValueReader(byteReader); });
 
-      const bufferReader = new bbr.ByteBufferReader();
-      assert.doesNotThrow(() => { scalarValueReader = new svr.ScalarValueReader(bufferReader); });
+      const byteBufferReader = new bbr.ByteBufferReader();
+      assert.doesNotThrow(() => { scalarValueReader = new svr.ScalarValueReader(byteBufferReader); });
     });
   });
   describe("read()", function () {
@@ -586,7 +586,7 @@ describe('ScalarValueReader', function() {
         //{{/w==}} (base64 representation)
         [parseInt('0xFF', 16)]
       ));
-      value = scalarValueReader.read(IonTypes["clob"],0,1);
+      value = scalarValueReader.read(IonTypes["blob"],0,1);
       assert.deepStrictEqual(value, new Uint8Array([255]));
 
       bufferReader.loadBuffer(new Uint8Array(
@@ -597,7 +597,7 @@ describe('ScalarValueReader', function() {
          parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
          parseInt('0xFF', 16)]
       ));
-      value = scalarValueReader.read(IonTypes["clob"],0,13);
+      value = scalarValueReader.read(IonTypes["blob"],0,13);
       assert.deepStrictEqual(value, new Uint8Array([255,255,255,255,255,255,255,255,255,255,255,255,255]));
     });
   });

--- a/test/core/ScalarValueReader.spec.js
+++ b/test/core/ScalarValueReader.spec.js
@@ -10,15 +10,15 @@ let bufferReader;
 describe('ScalarValueReader', function() {
   describe("constructor", function () {
     it('should require a byte reader as a parameter', function() {
-      assert.throws(() => { new svr.ScalarValueReader(); }, 
-                    "ScalarValueReader expected byteReader to be a ByteReader." );
+      assert.throws(() => { scalarValueReader = new svr.ScalarValueReader(); }, 
+                          "ScalarValueReader expected byteReader to be a ByteReader." );
     });
     it('should accept a byte reader as a parameter', function() {
       const byteReader = new br.ByteReader();
-      assert.doesNotThrow(() => { new svr.ScalarValueReader(byteReader); });
+      assert.doesNotThrow(() => { scalarValueReader = new svr.ScalarValueReader(byteReader); });
 
       const bufferReader = new bbr.ByteBufferReader();
-      assert.doesNotThrow(() => { new svr.ScalarValueReader(bufferReader); });
+      assert.doesNotThrow(() => { scalarValueReader = new svr.ScalarValueReader(bufferReader); });
     });
   });
   describe("read()", function () {
@@ -28,9 +28,9 @@ describe('ScalarValueReader', function() {
     });
     it('should fail when passed a non-existent type', function() {
       assert.throws(() => { scalarValueReader.read(19 , 0, 2); },
-                            "ScalarValueReader read() called with non-existant type 19.");
+                            "ScalarValueReader read() called with non-existent type 19.");
       assert.throws(() => { scalarValueReader.read('foo', 0, 2); },
-                            "ScalarValueReader read() called with non-existant type foo.");
+                            "ScalarValueReader read() called with non-existent type foo.");
     });
     it('should fail when passed a non-scalar type', function() {
       assert.throws(() => { scalarValueReader.read(IonTypes["null"], 0, 2); },

--- a/test/core/ScalarValueReader.spec.js
+++ b/test/core/ScalarValueReader.spec.js
@@ -1,0 +1,604 @@
+const { assert } = require('chai');
+const svr = require("../../src/core/ScalarValueReader");
+const bbr = require('../../src/core/ByteBufferReader');
+const br = require('../../src/core/ByteReader');
+const { IonTypes } = require('../../src/core/IonTypes');
+
+let scalarValueReader;
+let bufferReader;
+
+describe('ScalarValueReader', function() {
+  describe("constructor", function () {
+    it('should require a byte reader as a parameter', function() {
+      assert.throws(() => { new svr.ScalarValueReader(); }, 
+                    "ScalarValueReader expected byteReader to be a ByteReader." );
+    });
+    it('should accept a byte reader as a parameter', function() {
+      const byteReader = new br.ByteReader();
+      assert.doesNotThrow(() => { new svr.ScalarValueReader(byteReader); });
+
+      const bufferReader = new bbr.ByteBufferReader();
+      assert.doesNotThrow(() => { new svr.ScalarValueReader(bufferReader); });
+    });
+  });
+  describe("read()", function () {
+    beforeEach(function () {
+      bufferReader = new bbr.ByteBufferReader();
+      scalarValueReader = new svr.ScalarValueReader(bufferReader);
+    });
+    it('should fail when passed a non-existent type', function() {
+      assert.throws(() => { scalarValueReader.read(19 , 0, 2); },
+                            "ScalarValueReader read() called with non-existant type 19.");
+      assert.throws(() => { scalarValueReader.read('foo', 0, 2); },
+                            "ScalarValueReader read() called with non-existant type foo.");
+    });
+    it('should fail when passed a non-scalar type', function() {
+      assert.throws(() => { scalarValueReader.read(IonTypes["null"], 0, 2); },
+                            "ScalarValueReader called on null, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["bool"], 0, 2); },
+                            "ScalarValueReader called on bool, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["list"], 0, 2); },
+                            "ScalarValueReader called on list, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["sexp"], 0, 2); },
+                            "ScalarValueReader called on sexp, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["struct"], 0, 2); },
+                            "ScalarValueReader called on struct, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["annotation"], 0, 2); },
+                            "ScalarValueReader called on annotation, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["reserved"], 0, 2); },
+                            "ScalarValueReader called on reserved, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["bvm"], 0, 2); },
+                            "ScalarValueReader called on bvm, a non-scalar.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["nop"], 0, 2); },
+                            "ScalarValueReader called on nop, a non-scalar.");
+    });
+    it('should fail when passed an invalid position', function() {
+      assert.throws(() => { scalarValueReader.read(IonTypes["int+"], -1, 2); },
+                            "ScalarValueReader read() called with invalid position -1.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["int+"], null, 2); },
+                            "ScalarValueReader read() called with invalid position null.");
+    });
+    it('should fail when passed an invalid length', function() {
+      assert.throws(() => { scalarValueReader.read(IonTypes["int+"], 0, -1); },
+                            "ScalarValueReader read() called with invalid length -1.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["int+"], 0, null); },
+                            "ScalarValueReader read() called with invalid length null.");
+    });
+    it('should read positive ints', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int+"],0,1);
+      assert.strictEqual(value, 0);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int+"],0,1);
+      assert.strictEqual(value, 255);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int+"],0,2);
+      assert.strictEqual(value, 65535);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int+"],0,4);
+      assert.strictEqual(value, 0n);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int+"],0,4);
+      assert.strictEqual(value, 4294967295n);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int+"],0,14);
+      assert.strictEqual(value, 5192296858534827628530496329220095n);
+    });
+    it('should read negative ints', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int-"],0,1);
+      assert.strictEqual(value, -255);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int-"],0,2);
+      assert.strictEqual(value, -65535);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int-"],0,4);
+      assert.strictEqual(value, -4294967295n);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["int-"],0,14);
+      assert.strictEqual(value, -5192296858534827628530496329220095n);
+    });
+    it('should fail when finding a 0 with negative ints', function() {
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      assert.throws(() => { scalarValueReader.read(IonTypes["int-"],0,1); },
+                            "readNegativeInt() zero not a valid negative int value.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["int-"],0,4); },
+                            "readNegativeInt() zero not a valid negative int value.");
+    });
+    it('should read floats', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["float"],0,4);
+      assert.strictEqual(value, 4.609175024471393E-28);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16),
+         parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["float"],0,8);
+      assert.strictEqual(value, 1.2497855238365512E-221);
+    });
+    it('should fail floats when given an invalid length', function() {
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16), parseInt('0x12', 16)]
+      ));
+      assert.throws(() => { scalarValueReader.read(IonTypes["float"],0,1); },
+                            "ScalarValueReader illegal float length 1.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["float"],0,2); },
+                            "ScalarValueReader illegal float length 2.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["float"],0,3); },
+                            "ScalarValueReader illegal float length 3.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["float"],0,5); },
+                            "ScalarValueReader illegal float length 5.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["float"],0,6); },
+                            "ScalarValueReader illegal float length 6.");
+      assert.throws(() => { scalarValueReader.read(IonTypes["float"],0,7); },
+                            "ScalarValueReader illegal float length 7.");
+    });
+    it('should read 1 byte decimals', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["decimal"],0,1);
+      assert.strictEqual(value.coefficient.magnitude, 0);
+      assert.strictEqual(value.exponent.magnitude, -63);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xBF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["decimal"],0,1);
+      assert.strictEqual(value.coefficient.magnitude, 0);
+      assert.strictEqual(value.exponent.magnitude, 63);
+    });
+    it('should read 2 byte decimals', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["decimal"],0,2);
+      assert.strictEqual(value.coefficient.magnitude, -127);
+      assert.strictEqual(value.exponent.magnitude, -63);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xBF', 16), parseInt('0x7F', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["decimal"],0,2);
+      assert.strictEqual(value.coefficient.magnitude, 127);
+      assert.strictEqual(value.exponent.magnitude, 63);
+    });
+    it('should read 15 byte decimals', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16), parseInt('0x7F', 16),
+         parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0x7F', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["decimal"],0,15);
+      assert.strictEqual(value.coefficient.magnitude, 127);
+      assert.strictEqual(value.exponent.magnitude, -158456325028528675187087900671n);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xBF', 16), parseInt('0x7F', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["decimal"],0,15);
+      assert.strictEqual(value.coefficient.magnitude, 2596148429267413814265248164610047n);
+      assert.strictEqual(value.exponent.magnitude, 63);
+    });
+    it('should read 2 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,2);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month, undefined);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xC0', 16), parseInt('0xE1', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,2);
+      assert.strictEqual(value.offset.magnitude, -0);
+      assert.strictEqual(value.year.magnitude, 97);
+      assert.strictEqual(value.month, undefined);
+    });
+    it('should read 3 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x06', 16), parseInt('0xC8', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,3);
+      // +14 hours (Line Islands)
+      assert.strictEqual(value.offset.magnitude, 840);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month, undefined);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x10', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,3);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 2048);
+      assert.strictEqual(value.month, undefined);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,3);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day, undefined);
+    });
+    it('should read 4 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,4);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day.magnitude, 0);
+      assert.strictEqual(value.hour, undefined);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x06', 16), parseInt('0xC8', 16), parseInt('0x10', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,4);
+      // +14 hours (Line Islands)
+      assert.strictEqual(value.offset.magnitude, 840);
+      assert.strictEqual(value.year.magnitude, 2048);
+      assert.strictEqual(value.month, undefined);
+    });
+    it('should fail on 5 byte timestamps with hour and without minutes', function () {
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16)]
+      ));
+      assert.throws(() => { scalarValueReader.read(IonTypes["timestamp"],0,5); },
+                            "ScalarValueReader hours present without minutes.");
+    });
+    it('should read 5 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x06', 16), parseInt('0xC8', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,5);
+      // +14 hours (Line Islands)
+      assert.strictEqual(value.offset.magnitude, 840);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day.magnitude, 0);
+      assert.strictEqual(value.hour, undefined);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x06', 16), parseInt('0xC8', 16), parseInt('0x10', 16), parseInt('0x80', 16),
+         parseInt('0x86', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,5);
+      // +14 hours (Line Islands)
+      assert.strictEqual(value.offset.magnitude, 840);
+      assert.strictEqual(value.year.magnitude, 2048);
+      assert.strictEqual(value.month.magnitude, 6);
+      assert.strictEqual(value.day, undefined);
+    });
+    it('should read 6 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,6);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day.magnitude, 0);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second, undefined);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x06', 16), parseInt('0xC8', 16), parseInt('0x10', 16), parseInt('0x80', 16),
+         parseInt('0x86', 16), parseInt('0x83')]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,6);
+      // +14 hours (Line Islands)
+      assert.strictEqual(value.offset.magnitude, 840);
+      assert.strictEqual(value.year.magnitude, 2048);
+      assert.strictEqual(value.month.magnitude, 6);
+      assert.strictEqual(value.day.magnitude, 3);
+      assert.strictEqual(value.hour, undefined);
+    });
+    it('should read 7 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,7);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day.magnitude, 0);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent, undefined);
+    });
+    it('should read 8 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,8);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day.magnitude, 0);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.numBytesRead, 0);
+
+      // 2000-01-01T00:00:00Z with no fractional seconds
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x0F', 16), parseInt('0xD0', 16), parseInt('0x81', 16),
+         parseInt('0x81', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,8);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 2000);
+      assert.strictEqual(value.month.magnitude, 1);
+      assert.strictEqual(value.day.magnitude, 1);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent, undefined);
+    });
+    it('should read 9 byte timestamps', function () {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x00', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,9);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 0);
+      assert.strictEqual(value.month.magnitude, 0);
+      assert.strictEqual(value.day.magnitude, 0);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.numBytesRead, 1);
+
+      // 2000-01-01T00:00:00Z with 0d0 fractional seconds and implicit zero coefficient
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x0F', 16), parseInt('0xD0', 16), parseInt('0x81', 16),
+         parseInt('0x81', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,9);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 2000);
+      assert.strictEqual(value.month.magnitude, 1);
+      assert.strictEqual(value.day.magnitude, 1);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.numBytesRead, 0);
+
+      // 2000-01-01T00:00:00Z with 0d-0 fractional seconds
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x0F', 16), parseInt('0xD0', 16), parseInt('0x81', 16),
+         parseInt('0x81', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0xC0', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,9);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 2000);
+      assert.strictEqual(value.month.magnitude, 1);
+      assert.strictEqual(value.day.magnitude, 1);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent.magnitude, -0);
+      assert.strictEqual(value.fractionExponent.isNegative, true);
+      assert.strictEqual(value.fractionCoefficient.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.numBytesRead, 0);
+
+      // 2000-01-01T00:00:00Z with 0d1 fractional seconds
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x0F', 16), parseInt('0xD0', 16), parseInt('0x81', 16),
+         parseInt('0x81', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x81', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,9);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 2000);
+      assert.strictEqual(value.month.magnitude, 1);
+      assert.strictEqual(value.day.magnitude, 1);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent.magnitude, 1);
+      assert.strictEqual(value.fractionCoefficient.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.numBytesRead, 0);
+    });
+    it('should read 10 byte timestamps', function () {
+      let value;
+      
+      // 2000-01-01T00:00:00Z with 0d0 fractional seconds and explicit zero coefficient
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x80', 16), parseInt('0x0F', 16), parseInt('0xD0', 16), parseInt('0x81', 16),
+         parseInt('0x81', 16), parseInt('0x80', 16), parseInt('0x80', 16), parseInt('0x80', 16),
+         parseInt('0x80', 16), parseInt('0x00', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["timestamp"],0,10);
+      assert.strictEqual(value.offset.magnitude, 0);
+      assert.strictEqual(value.year.magnitude, 2000);
+      assert.strictEqual(value.month.magnitude, 1);
+      assert.strictEqual(value.day.magnitude, 1);
+      assert.strictEqual(value.hour.magnitude, 0);
+      assert.strictEqual(value.minute.magnitude, 0);
+      assert.strictEqual(value.second.magnitude, 0);
+      assert.strictEqual(value.fractionExponent.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.magnitude, 0);
+      assert.strictEqual(value.fractionCoefficient.numBytesRead, 1);
+    });
+    it('should read symbols', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["symbol"],0,1);
+      assert.strictEqual(value, 0);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["symbol"],0,1);
+      assert.strictEqual(value, 255);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["symbol"],0,2);
+      assert.strictEqual(value, 65535);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16), parseInt('0x00', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["symbol"],0,4);
+      assert.strictEqual(value, 0n);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["symbol"],0,4);
+      assert.strictEqual(value, 4294967295n);
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["symbol"],0,14);
+      assert.strictEqual(value, 5192296858534827628530496329220095n);
+    });
+    it('should read strings', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x30', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["string"],0,1);
+      assert.strictEqual(value, "0");
+
+      bufferReader.loadBuffer(new Uint8Array(
+        [parseInt('0x30', 16), parseInt('0x30', 16), parseInt('0x30', 16), parseInt('0x30', 16),
+         parseInt('0x30', 16), parseInt('0x30', 16), parseInt('0x30', 16), parseInt('0x30', 16),
+         parseInt('0x30', 16), parseInt('0x30', 16), parseInt('0x30', 16), parseInt('0x30', 16),
+         parseInt('0x30', 16), parseInt('0x30', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["string"],0,14);
+      assert.strictEqual(value, "00000000000000");
+    });
+    it('should read clobs', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        //1 byte clob
+        //{{ "\xFF" }}
+        [parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["clob"],0,1);
+      assert.deepStrictEqual(value, new Uint8Array([255]));
+
+      bufferReader.loadBuffer(new Uint8Array(
+        //13 byte clob
+        //{{"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"}}
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), 
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["clob"],0,13);
+      assert.deepStrictEqual(value, new Uint8Array([255,255,255,255,255,255,255,255,255,255,255,255,255]));
+    });
+    it('should read blobs', function() {
+      let value;
+      bufferReader.loadBuffer(new Uint8Array(
+        //1 byte blob
+        //{{/w==}} (base64 representation)
+        [parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["clob"],0,1);
+      assert.deepStrictEqual(value, new Uint8Array([255]));
+
+      bufferReader.loadBuffer(new Uint8Array(
+        //13 byte blob
+        //{{/////////////////w==}} (base64 representation)
+        [parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), 
+         parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16), parseInt('0xFF', 16),
+         parseInt('0xFF', 16)]
+      ));
+      value = scalarValueReader.read(IonTypes["clob"],0,13);
+      assert.deepStrictEqual(value, new Uint8Array([255,255,255,255,255,255,255,255,255,255,255,255,255]));
+    });
+  });
+});


### PR DESCRIPTION
This is the second import of the code currently running on the website. It has been cleaned up from the original source. Addresses part of https://github.com/jonwilsdon/ion-binary-explorer/issues/1.

Includes:

ElementReference: Contains the structural information about an element.
ScalarValueReader: Reads Ion scalar values (beyond the Type Descriptor) from a ByteReader.
ElementReference: Stores the "structure" (T/L and length) of an Ion element.